### PR TITLE
M2: semantic analysis — symbol table, type system, name resolution, t…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ add_executable(dux
     src/main.cpp
     src/ast/ast.cpp
     src/driver/driver.cpp
+    src/sema/types.cpp
+    src/sema/symbol.cpp
+    src/sema/sema.cpp
     ${FLEX_DuxLexer_OUTPUTS}
     ${BISON_DuxParser_OUTPUTS}
 )
@@ -108,6 +111,29 @@ foreach(F ${DUX_PARSE_FAIL})
         COMMAND dux ${F}
     )
     set_tests_properties(parse_fail_${name} PROPERTIES
+        WILL_FAIL TRUE
+    )
+endforeach()
+
+# sema_ok: files that must pass semantic analysis (exit 0 with --check)
+file(GLOB DUX_SEMA_OK "${CMAKE_SOURCE_DIR}/tests/sema_ok/*.dux")
+foreach(F ${DUX_SEMA_OK})
+    cmake_path(GET F STEM name)
+    add_test(
+        NAME    sema_ok_${name}
+        COMMAND dux --check ${F}
+    )
+endforeach()
+
+# sema_fail: files that must fail semantic analysis (exit non-zero with --check)
+file(GLOB DUX_SEMA_FAIL "${CMAKE_SOURCE_DIR}/tests/sema_fail/*.dux")
+foreach(F ${DUX_SEMA_FAIL})
+    cmake_path(GET F STEM name)
+    add_test(
+        NAME    sema_fail_${name}
+        COMMAND dux --check ${F}
+    )
+    set_tests_properties(sema_fail_${name} PROPERTIES
         WILL_FAIL TRUE
     )
 endforeach()

--- a/src/ast/ast.hpp
+++ b/src/ast/ast.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -31,7 +32,9 @@ struct TypeExpr {
 
 // ─── Expressions ─────────────────────────────────────────────────────────────
 
-struct Expr : Node {};
+struct Expr : Node {
+    mutable int32_t type_id{-1};  // filled in by sema pass; -1 = unresolved
+};
 using ExprPtr  = std::unique_ptr<Expr>;
 using ExprList = std::vector<ExprPtr>;
 

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <iostream>
 
+
 /* ─── Flex interface ────────────────────────────────────────────────────── */
 extern int   yylex_destroy();
 extern FILE* yyin;
@@ -108,4 +109,20 @@ dux::ast::SourceLoc Driver::make_loc(const yy::location& l) const {
     sl.line = l.begin.line;
     sl.col  = l.begin.column;
     return sl;
+}
+
+void Driver::error(const dux::ast::SourceLoc& sl, const std::string& msg) {
+    yy::position p;
+    p.filename = &filename_;
+    p.line     = static_cast<unsigned>(sl.line > 0 ? sl.line : 1);
+    p.column   = static_cast<unsigned>(sl.col  > 0 ? sl.col  : 1);
+    error(yy::location(p, p), msg);
+}
+
+void Driver::warning(const dux::ast::SourceLoc& sl, const std::string& msg) {
+    yy::position p;
+    p.filename = &filename_;
+    p.line     = static_cast<unsigned>(sl.line > 0 ? sl.line : 1);
+    p.column   = static_cast<unsigned>(sl.col  > 0 ? sl.col  : 1);
+    warning(yy::location(p, p), msg);
 }

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -30,13 +30,15 @@ public:
     // Emit a clang-style error with source context. Throws DiagnosticAbort
     // once kMaxErrors have been accumulated.
     void error(const yy::location& l, const std::string& msg);
+    void error(const dux::ast::SourceLoc& l, const std::string& msg);
 
     // Emit a warning (never throws, never increments error count).
     void warning(const yy::location& l, const std::string& msg);
+    void warning(const dux::ast::SourceLoc& l, const std::string& msg);
 
     int  error_count() const { return error_count_; }
 
-    // ─── Called by the lexer ─────────────────────────────────────────────────
+    // ─── Location conversions ────────────────────────────────────────────────
     dux::ast::SourceLoc make_loc(const yy::location& l) const;
 
     // String accumulation buffer for multi-character literals.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 
 #include "ast/printer.hpp"
 #include "driver/driver.hpp"
+#include "sema/sema.hpp"
 
 #ifndef DUX_VERSION
 #define DUX_VERSION "0.1.0-dev"
@@ -16,6 +17,7 @@ namespace {
 struct Options {
     std::string  input;
     bool         dump_ast{false};
+    bool         check{false};
     bool         trace_lex{false};
     bool         trace_parse{false};
     bool         help{false};
@@ -28,6 +30,7 @@ void usage(std::string_view prog) {
         "\n"
         "Options:\n"
         "  --dump-ast      Print the parsed AST to stdout\n"
+        "  --check         Run semantic analysis and report errors\n"
         "  --trace-lex     Enable flex debug output\n"
         "  --trace-parse   Enable bison debug output\n"
         "  --version       Print version and exit\n"
@@ -41,6 +44,7 @@ Options parse_args(std::span<char*> args) {
     for (std::size_t i = 1; i < args.size(); ++i) {
         std::string_view a = args[i];
         if      (a == "--dump-ast")            { opts.dump_ast    = true; }
+        else if (a == "--check")               { opts.check       = true; }
         else if (a == "--trace-lex")           { opts.trace_lex   = true; }
         else if (a == "--trace-parse")         { opts.trace_parse = true; }
         else if (a == "--version")             { opts.version     = true; }
@@ -75,6 +79,13 @@ int main(int argc, char** argv) {
     driver.trace_parsing  = opts.trace_parse;
 
     int rc = driver.parse(opts.input);
+    if (rc != 0) return EXIT_FAILURE;
+
+    if (opts.check && driver.result) {
+        dux::sema::Sema sema(driver);
+        sema.run(*driver.result);
+        if (sema.error_count() > 0) rc = 1;
+    }
 
     if (opts.dump_ast && driver.result && driver.error_count() == 0) {
         dux::ast::Printer printer(std::cout);

--- a/src/sema/sema.cpp
+++ b/src/sema/sema.cpp
@@ -1,0 +1,766 @@
+#include "sema/sema.hpp"
+#include "driver/driver.hpp"
+#include <sstream>
+
+namespace dux::sema {
+
+using TR = TypeRegistry;
+
+// ─── Constructor ─────────────────────────────────────────────────────────────
+
+Sema::Sema(Driver& driver) : driver_(driver) {
+    // Pre-populate global scope with built-in functions.
+    auto builtin = [&](const std::string& name, TypeId ret,
+                       std::vector<std::pair<std::string, TypeId>> params = {}) {
+        Symbol s;
+        s.name        = name;
+        s.kind        = SymKind::BuiltIn;
+        s.type        = ret;
+        s.return_type = ret;
+        s.params      = std::move(params);
+        scopes_.define(name, std::move(s));
+    };
+
+    builtin("println",  TR::TID_VOID, {{"value", TR::TID_OBJECT}});
+    builtin("print",    TR::TID_VOID, {{"value", TR::TID_OBJECT}});
+    builtin("readline", TR::TID_STR);
+    builtin("len",      TR::TID_INT,  {{"x", TR::TID_OBJECT}});
+    builtin("str",      TR::TID_STR,  {{"x", TR::TID_OBJECT}});
+    builtin("int",      TR::TID_INT,  {{"x", TR::TID_OBJECT}});
+    builtin("double",   TR::TID_DOUBLE, {{"x", TR::TID_OBJECT}});
+    builtin("range",    TR::TID_LIST, {{"end", TR::TID_INT}});
+    builtin("assert",   TR::TID_VOID, {{"cond", TR::TID_BOOL}});
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+bool Sema::run(const ast::Program& prog) {
+    hoist_top(prog.decls);
+    for (const auto& d : prog.decls) check_decl(*d);
+    check_stmts(prog.stmts);
+    return error_count_ == 0;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+void Sema::err(const ast::SourceLoc& loc, const std::string& msg) {
+    driver_.error(loc, msg);
+    ++error_count_;
+}
+
+void Sema::warn(const ast::SourceLoc& loc, const std::string& msg) {
+    driver_.warning(loc, msg);
+}
+
+TypeId Sema::type_from_te(const ast::TypeExpr& te) const {
+    TypeId id = types_.from_type_expr(te);
+    return id == TR::TID_UNKNOWN ? TR::TID_UNKNOWN : id;
+}
+
+bool Sema::require_assignable(TypeId from, TypeId to,
+                              const ast::SourceLoc& loc, const std::string& ctx) {
+    if (types_.assignable(from, to)) return true;
+    std::ostringstream os;
+    os << ctx << ": cannot assign '" << types_.name_of(from)
+       << "' to '" << types_.name_of(to) << "'";
+    err(loc, os.str());
+    return false;
+}
+
+bool Sema::require_numeric(TypeId t, const ast::SourceLoc& loc, const std::string& ctx) {
+    if (t == TR::TID_UNKNOWN || types_.is_numeric(t)) return true;
+    err(loc, ctx + ": expected numeric type, got '" + types_.name_of(t) + "'");
+    return false;
+}
+
+bool Sema::require_bool(TypeId t, const ast::SourceLoc& loc, const std::string& ctx) {
+    if (t == TR::TID_UNKNOWN || t == TR::TID_BOOL ||
+        types_.assignable(t, TR::TID_BOOL)) return true;
+    // Allow any type in boolean context (like C / Python — warn only)
+    warn(loc, ctx + ": condition is '" + types_.name_of(t) + "', expected 'bool'");
+    return true;
+}
+
+// ─── Hoisting (pass 1) ───────────────────────────────────────────────────────
+
+void Sema::hoist_top(const ast::DeclList& decls) {
+    for (const auto& dp : decls) {
+        if (auto* c = dynamic_cast<const ast::ClassDecl*>(dp.get()))
+            hoist_class(*c);
+        else if (auto* i = dynamic_cast<const ast::InterfaceDecl*>(dp.get()))
+            hoist_interface(*i);
+        else if (auto* ns = dynamic_cast<const ast::NamespaceDecl*>(dp.get()))
+            hoist_namespace(*ns);
+        else if (auto* f = dynamic_cast<const ast::FunctionDecl*>(dp.get())) {
+            TypeId ret = type_from_te(f->return_type);
+            Symbol s;
+            s.name        = f->name;
+            s.kind        = SymKind::Function;
+            s.type        = ret;
+            s.return_type = ret;
+            s.decl        = dp.get();
+            s.loc         = f->loc;
+            for (const auto& p : f->params)
+                s.params.emplace_back(p.name, type_from_te(p.type));
+            if (!scopes_.define(s.name, s))
+                err(f->loc, "function '" + f->name + "' already declared in this scope");
+        }
+    }
+}
+
+void Sema::hoist_class(const ast::ClassDecl& c) {
+    TypeId id = types_.intern(c.name, TypeKind::Class);
+    // Wire up parent
+    if (!c.bases.empty()) {
+        TypeId parent = types_.from_name(c.bases[0].name);
+        if (parent == TR::TID_UNKNOWN) parent = TR::TID_OBJECT;
+        types_.set_parent(id, parent);
+    }
+    Symbol s;
+    s.name = c.name;
+    s.kind = SymKind::Class;
+    s.type = id;
+    s.decl = const_cast<ast::ClassDecl*>(&c);
+    s.loc  = c.loc;
+    if (!scopes_.define(s.name, s))
+        err(c.loc, "class '" + c.name + "' already declared");
+}
+
+void Sema::hoist_interface(const ast::InterfaceDecl& i) {
+    TypeId id = types_.intern(i.name, TypeKind::Interface);
+    Symbol s;
+    s.name = i.name;
+    s.kind = SymKind::Interface;
+    s.type = id;
+    s.decl = const_cast<ast::InterfaceDecl*>(&i);
+    s.loc  = i.loc;
+    if (!scopes_.define(s.name, s))
+        err(i.loc, "interface '" + i.name + "' already declared");
+}
+
+void Sema::hoist_namespace(const ast::NamespaceDecl& ns) {
+    Symbol s;
+    s.name = ns.name;
+    s.kind = SymKind::Namespace;
+    s.type = TR::TID_UNKNOWN;
+    s.decl = const_cast<ast::NamespaceDecl*>(&ns);
+    s.loc  = ns.loc;
+    scopes_.define(s.name, s); // namespaces can shadow, don't error
+    // Also hoist the namespace's own decls into global scope (flat for now)
+    scopes_.push();
+    hoist_top(ns.decls);
+    // Promote to global scope so namespace members are reachable
+    scopes_.current_scope().for_each([&](const std::string& name, const Symbol& sym) {
+        Symbol qualified = sym;
+        qualified.name   = ns.name + "." + name;
+        scopes_.global_scope().define(qualified.name, qualified);
+        // Also unqualified within same namespace context
+        scopes_.global_scope().define(name, sym);
+    });
+    scopes_.pop();
+}
+
+// ─── Declarations ────────────────────────────────────────────────────────────
+
+void Sema::check_decl(const ast::Decl& d) {
+    if (auto* f  = dynamic_cast<const ast::FunctionDecl*>(&d))  check_func(*f);
+    else if (auto* c  = dynamic_cast<const ast::ClassDecl*>(&d))     check_class(*c);
+    else if (auto* i  = dynamic_cast<const ast::InterfaceDecl*>(&d)) check_interface(*i);
+    else if (auto* ns = dynamic_cast<const ast::NamespaceDecl*>(&d)) check_namespace(*ns);
+    else if (auto* im = dynamic_cast<const ast::ImportDecl*>(&d))    check_import(*im);
+}
+
+void Sema::check_func(const ast::FunctionDecl& f, TypeId /*class_type*/) {
+    TypeId ret = type_from_te(f.return_type);
+    scopes_.push();
+
+    // Define 'this' if inside a class
+    if (!current_class_name_.empty()) {
+        Symbol th;
+        th.name = "this";
+        th.kind = SymKind::Var;
+        th.type = current_class_type_;
+        scopes_.define("this", th);
+
+        // Define 'super' as the parent class type
+        TypeId parent = types_.info(current_class_type_).parent;
+        if (parent != TR::TID_UNKNOWN && parent >= 0) {
+            Symbol su;
+            su.name = "super";
+            su.kind = SymKind::Var;
+            su.type = parent;
+            scopes_.define("super", su);
+        }
+    }
+
+    // Define parameters
+    for (const auto& p : f.params) {
+        Symbol sym;
+        sym.name = p.name;
+        sym.kind = SymKind::Param;
+        sym.type = type_from_te(p.type);
+        sym.loc  = p.type.loc;
+        if (!scopes_.define(p.name, sym))
+            err(p.type.loc, "duplicate parameter '" + p.name + "'");
+    }
+
+    // Check body
+    auto saved_ret  = current_return_type_;
+    current_return_type_ = ret;
+
+    if (f.body) check_stmts(f.body->body);
+
+    current_return_type_ = saved_ret;
+    scopes_.pop();
+}
+
+void Sema::check_class(const ast::ClassDecl& c) {
+    TypeId class_type = types_.from_name(c.name);
+
+    // Validate base classes
+    for (const auto& base : c.bases) {
+        Symbol* bs = scopes_.lookup(base.name);
+        if (!bs) {
+            err(c.loc, "unknown base class '" + base.name + "'");
+        } else if (bs->kind != SymKind::Class && bs->kind != SymKind::Interface) {
+            err(c.loc, "'" + base.name + "' is not a class or interface");
+        } else {
+            types_.set_parent(class_type, bs->type);
+        }
+    }
+
+    auto saved_class  = current_class_name_;
+    auto saved_ctype  = current_class_type_;
+    current_class_name_ = c.name;
+    current_class_type_ = class_type;
+
+    // Hoist member function names into the class scope first
+    scopes_.push(true);
+    for (const auto& m : c.members) {
+        if (!m.decl) continue;
+        if (auto* f = dynamic_cast<const ast::FunctionDecl*>(m.decl.get())) {
+            Symbol sym;
+            sym.name        = f->name;
+            sym.kind        = SymKind::Function;
+            sym.type        = type_from_te(f->return_type);
+            sym.return_type = sym.type;
+            sym.decl        = m.decl.get();
+            sym.loc         = f->loc;
+            for (const auto& p : f->params)
+                sym.params.emplace_back(p.name, type_from_te(p.type));
+            scopes_.define(sym.name, sym);
+        } else if (auto* fd = dynamic_cast<const ast::FieldDecl*>(m.decl.get())) {
+            Symbol sym;
+            sym.name = fd->name;
+            sym.kind = SymKind::Var;
+            sym.type = type_from_te(fd->type);
+            sym.decl = m.decl.get();
+            sym.loc  = fd->loc;
+            scopes_.define(sym.name, sym);
+        }
+    }
+
+    // Check members
+    for (const auto& m : c.members) {
+        if (!m.decl) continue;
+        if (auto* f = dynamic_cast<const ast::FunctionDecl*>(m.decl.get()))
+            check_func(*f, class_type);
+        else if (auto* fd = dynamic_cast<const ast::FieldDecl*>(m.decl.get())) {
+            if (fd->init) {
+                TypeId init_t = check_expr(**fd->init);
+                TypeId decl_t = type_from_te(fd->type);
+                require_assignable(init_t, decl_t, fd->loc,
+                                   "field '" + fd->name + "' initialiser");
+            }
+        }
+    }
+
+    scopes_.pop();
+    current_class_name_ = saved_class;
+    current_class_type_ = saved_ctype;
+}
+
+void Sema::check_interface(const ast::InterfaceDecl& i) {
+    // Interface members are abstract; just validate the method signatures.
+    for (const auto& m : i.members) {
+        if (!m.decl) continue;
+        if (auto* f = dynamic_cast<const ast::FunctionDecl*>(m.decl.get())) {
+            TypeId ret = type_from_te(f->return_type);
+            if (ret == TR::TID_UNKNOWN && !f->return_type.name.empty())
+                warn(f->loc, "interface method '" + f->name + "': unknown return type '" +
+                              f->return_type.name + "'");
+        }
+    }
+}
+
+void Sema::check_namespace(const ast::NamespaceDecl& ns) {
+    scopes_.push();
+    hoist_top(ns.decls);
+    for (const auto& d : ns.decls) check_decl(*d);
+    check_stmts(ns.stmts);
+    scopes_.pop();
+}
+
+void Sema::check_import(const ast::ImportDecl& imp) {
+    // Simplified: register the module name as an object-typed symbol.
+    // Full resolution (loading files) is M5 work.
+    std::string first = imp.path.substr(0, imp.path.find('.'));
+    if (!first.empty() && !scopes_.lookup(first)) {
+        Symbol s;
+        s.name = first;
+        s.kind = SymKind::Namespace;
+        s.type = TR::TID_OBJECT;
+        scopes_.define(first, s);
+    }
+}
+
+// ─── Statements ──────────────────────────────────────────────────────────────
+
+void Sema::check_stmts(const ast::StmtList& stmts) {
+    for (const auto& sp : stmts) check_stmt(*sp);
+}
+
+void Sema::check_stmt(const ast::Stmt& s) {
+    if (auto* b  = dynamic_cast<const ast::BlockStmt*>(&s))     { check_block(*b);    return; }
+    if (auto* e  = dynamic_cast<const ast::ExprStmt*>(&s))      { check_expr(*e->expr); return; }
+    if (auto* v  = dynamic_cast<const ast::VarDeclStmt*>(&s))   { check_var_decl(*v); return; }
+    if (auto* i  = dynamic_cast<const ast::IfStmt*>(&s))        { check_if(*i);       return; }
+    if (auto* w  = dynamic_cast<const ast::WhileStmt*>(&s))     { check_while(*w);    return; }
+    if (auto* dw = dynamic_cast<const ast::DoWhileStmt*>(&s))   { check_do_while(*dw);return; }
+    if (auto* fi = dynamic_cast<const ast::ForInStmt*>(&s))     { check_for_in(*fi);  return; }
+    if (auto* fc = dynamic_cast<const ast::ForCStmt*>(&s))      { check_for_c(*fc);   return; }
+    if (auto* sw = dynamic_cast<const ast::SwitchStmt*>(&s))    { check_switch(*sw);  return; }
+    if (auto* tc = dynamic_cast<const ast::TryCatchStmt*>(&s))  { check_try_catch(*tc);return;}
+    if (auto* r  = dynamic_cast<const ast::ReturnStmt*>(&s))    { check_return(*r);   return; }
+    if (auto* br = dynamic_cast<const ast::BreakStmt*>(&s))     {
+        if (!in_loop_) err(br->loc, "'break' outside of loop");
+        return;
+    }
+    if (auto* co = dynamic_cast<const ast::ContinueStmt*>(&s))  {
+        if (!in_loop_) err(co->loc, "'continue' outside of loop");
+        return;
+    }
+    if (auto* a  = dynamic_cast<const ast::AssertStmt*>(&s))    { check_assert(*a);   return; }
+    if (auto* d  = dynamic_cast<const ast::DeleteStmt*>(&s))    { check_delete(*d);   return; }
+    // LabeledStmt, etc. — visit the inner stmt
+    if (auto* ls = dynamic_cast<const ast::LabeledStmt*>(&s))   { check_stmt(*ls->stmt); return; }
+}
+
+void Sema::check_block(const ast::BlockStmt& b) {
+    scopes_.push();
+    check_stmts(b.body);
+    scopes_.pop();
+}
+
+void Sema::check_if(const ast::IfStmt& s) {
+    TypeId ct = check_expr(*s.cond);
+    require_bool(ct, s.cond->loc, "if condition");
+    check_stmt(*s.then_br);
+    if (s.else_br) check_stmt(*s.else_br);
+}
+
+void Sema::check_while(const ast::WhileStmt& s) {
+    TypeId ct = check_expr(*s.cond);
+    require_bool(ct, s.cond->loc, "while condition");
+    bool saved = in_loop_;
+    in_loop_ = true;
+    check_stmt(*s.body);
+    in_loop_ = saved;
+}
+
+void Sema::check_do_while(const ast::DoWhileStmt& s) {
+    bool saved = in_loop_;
+    in_loop_ = true;
+    check_stmt(*s.body);
+    in_loop_ = saved;
+    TypeId ct = check_expr(*s.cond);
+    require_bool(ct, s.cond->loc, "do-while condition");
+}
+
+void Sema::check_for_in(const ast::ForInStmt& s) {
+    TypeId iter_t = check_expr(*s.iterable);
+    (void)iter_t; // accept any iterable for now
+
+    scopes_.push();
+    Symbol var;
+    var.name = s.var_name;
+    var.kind = SymKind::Var;
+    var.type = type_from_te(s.var_type);
+    var.loc  = s.var_type.loc;
+    scopes_.define(s.var_name, var);
+
+    bool saved = in_loop_;
+    in_loop_ = true;
+    check_stmt(*s.body);
+    in_loop_ = saved;
+    scopes_.pop();
+}
+
+void Sema::check_for_c(const ast::ForCStmt& s) {
+    scopes_.push();
+    TypeId vt = type_from_te(s.var_type);
+    Symbol var;
+    var.name = s.var_name;
+    var.kind = SymKind::Var;
+    var.type = vt;
+    scopes_.define(s.var_name, var);
+
+    TypeId init_t = check_expr(*s.init);
+    require_assignable(init_t, vt, s.init->loc, "for init");
+    check_expr(*s.cond);
+    check_expr(*s.incr);
+
+    bool saved = in_loop_;
+    in_loop_ = true;
+    check_stmt(*s.body);
+    in_loop_ = saved;
+    scopes_.pop();
+}
+
+void Sema::check_switch(const ast::SwitchStmt& s) {
+    check_expr(*s.expr);
+    bool saved = in_loop_;
+    in_loop_ = true;
+    for (const auto& c : s.cases) {
+        if (c.value) check_expr(**c.value);
+        scopes_.push();
+        check_stmts(c.body);
+        scopes_.pop();
+    }
+    in_loop_ = saved;
+}
+
+void Sema::check_try_catch(const ast::TryCatchStmt& s) {
+    check_stmt(*s.try_body);
+    scopes_.push();
+    if (!s.catch_all && s.catch_var) {
+        Symbol cv;
+        cv.name = *s.catch_var;
+        cv.kind = SymKind::Var;
+        cv.type = s.catch_type ? type_from_te(*s.catch_type) : TR::TID_OBJECT;
+        scopes_.define(*s.catch_var, cv);
+    }
+    check_stmt(*s.catch_body);
+    scopes_.pop();
+}
+
+void Sema::check_return(const ast::ReturnStmt& s) {
+    if (s.value) {
+        TypeId val_t = check_expr(**s.value);
+        require_assignable(val_t, current_return_type_, (*s.value)->loc,
+                           "return value");
+    } else {
+        if (current_return_type_ != TR::TID_VOID &&
+            current_return_type_ != TR::TID_UNKNOWN)
+            warn(s.loc, "missing return value in non-void function");
+    }
+}
+
+void Sema::check_var_decl(const ast::VarDeclStmt& s) {
+    TypeId decl_type = type_from_te(s.type);
+    bool   is_const  = s.is_const;
+
+    for (const auto& [name, init_ptr] : s.decls) {
+        TypeId var_type = decl_type;
+
+        if (init_ptr) {
+            TypeId init_t = check_expr(*init_ptr);
+            if (var_type == TR::TID_UNKNOWN)
+                var_type = init_t;  // type inference
+            else
+                require_assignable(init_t, var_type, init_ptr->loc,
+                                   "variable '" + name + "' initialiser");
+        }
+
+        Symbol sym;
+        sym.name     = name;
+        sym.kind     = SymKind::Var;
+        sym.type     = var_type;
+        sym.is_const = is_const;
+        sym.loc      = s.loc;
+        if (!scopes_.define(name, sym))
+            err(s.loc, "variable '" + name + "' already declared in this scope");
+    }
+}
+
+void Sema::check_assert(const ast::AssertStmt& s) {
+    TypeId t = check_expr(*s.cond);
+    require_bool(t, s.cond->loc, "assert");
+}
+
+void Sema::check_delete(const ast::DeleteStmt& s) {
+    TypeId t = check_expr(*s.expr);
+    if (t != TR::TID_UNKNOWN && types_.is_numeric(t))
+        warn(s.expr->loc, "'delete' on numeric value — did you mean a pointer?");
+}
+
+// ─── Expressions ─────────────────────────────────────────────────────────────
+
+TypeId Sema::check_expr(const ast::Expr& e) {
+    TypeId result = TR::TID_UNKNOWN;
+
+    // Each branch uses a distinct name to avoid -Wshadow in the else-if chain.
+    if (dynamic_cast<const ast::IntLitExpr*>(&e)) {
+        result = TR::TID_INT;
+    } else if (dynamic_cast<const ast::FloatLitExpr*>(&e)) {
+        result = TR::TID_DOUBLE;
+    } else if (dynamic_cast<const ast::StringLitExpr*>(&e)) {
+        result = TR::TID_STR;
+    } else if (dynamic_cast<const ast::BoolLitExpr*>(&e)) {
+        result = TR::TID_BOOL;
+    } else if (dynamic_cast<const ast::NullLitExpr*>(&e)) {
+        result = TR::TID_NULL;
+    } else if (auto* id_e = dynamic_cast<const ast::IdentExpr*>(&e)) {
+        Symbol* sym = scopes_.lookup(id_e->name);
+        if (!sym) {
+            err(id_e->loc, "undefined identifier '" + id_e->name + "'");
+        } else {
+            result = sym->type;
+        }
+    } else if (dynamic_cast<const ast::ThisExpr*>(&e)) {
+        result = current_class_type_;
+    } else if (dynamic_cast<const ast::SuperExpr*>(&e)) {
+        result = types_.info(current_class_type_).parent;
+        if (result < 0) result = TR::TID_OBJECT;
+    } else if (auto* bin_e  = dynamic_cast<const ast::BinaryExpr*>(&e)) {
+        result = check_binary(*bin_e);
+    } else if (auto* un_e   = dynamic_cast<const ast::UnaryExpr*>(&e)) {
+        result = check_unary(*un_e);
+    } else if (auto* asgn_e = dynamic_cast<const ast::AssignExpr*>(&e)) {
+        result = check_assign(*asgn_e);
+    } else if (auto* call_e = dynamic_cast<const ast::CallExpr*>(&e)) {
+        result = check_call(*call_e);
+    } else if (auto* mem_e  = dynamic_cast<const ast::MemberExpr*>(&e)) {
+        result = check_member(*mem_e);
+    } else if (auto* idx_e  = dynamic_cast<const ast::IndexExpr*>(&e)) {
+        result = check_index(*idx_e);
+    } else if (auto* new_e  = dynamic_cast<const ast::NewExpr*>(&e)) {
+        result = check_new(*new_e);
+    } else if (auto* lst_e  = dynamic_cast<const ast::ListExpr*>(&e)) {
+        result = check_list(*lst_e);
+    } else if (auto* dct_e  = dynamic_cast<const ast::DictExpr*>(&e)) {
+        result = check_dict(*dct_e);
+    } else if (dynamic_cast<const ast::FormatExpr*>(&e)) {
+        result = TR::TID_STR;
+    }
+    // else: unknown Expr subtype — leave as TID_UNKNOWN
+
+    e.type_id = result;
+    return result;
+}
+
+TypeId Sema::check_assign(const ast::AssignExpr& e) {
+    TypeId rhs = check_expr(*e.value);
+
+    // For plain assignment to an undeclared identifier: implicit declaration
+    if (e.op == "=" && dynamic_cast<const ast::IdentExpr*>(e.target.get())) {
+        const auto& name =
+            static_cast<const ast::IdentExpr&>(*e.target).name;
+        if (!scopes_.lookup(name)) {
+            // Implicit var decl — Python-style inside function bodies
+            Symbol sym;
+            sym.name = name;
+            sym.kind = SymKind::Var;
+            sym.type = rhs;
+            sym.loc  = e.target->loc;
+            scopes_.define(name, sym);
+            e.target->type_id = rhs;
+            return rhs;
+        }
+    }
+
+    TypeId lhs = check_expr(*e.target);
+
+    // For compound assignment (+= etc.), LHS must be numeric (or str for +=)
+    if (e.op != "=") {
+        if (e.op == "+=" && lhs == TR::TID_STR) {
+            require_assignable(rhs, TR::TID_STR, e.value->loc, "'+=' on str");
+        } else {
+            require_numeric(lhs, e.target->loc, "compound assignment target");
+            require_numeric(rhs, e.value->loc,  "compound assignment value");
+        }
+        return lhs;
+    }
+
+    require_assignable(rhs, lhs, e.value->loc, "assignment");
+    return lhs;
+}
+
+TypeId Sema::check_binary(const ast::BinaryExpr& e) {
+    TypeId L = check_expr(*e.left);
+    TypeId R = check_expr(*e.right);
+    const std::string& op = e.op;
+
+    // Arithmetic operators
+    if (op == "+" || op == "-" || op == "*" || op == "/" || op == "%") {
+        if (op == "+" && (L == TR::TID_STR || R == TR::TID_STR)) {
+            // String concatenation — either side can be str; warn on type mismatch
+            if (L != TR::TID_STR)
+                warn(e.left->loc,  "'+' with str: left operand is '" + types_.name_of(L) + "'");
+            if (R != TR::TID_STR)
+                warn(e.right->loc, "'+' with str: right operand is '" + types_.name_of(R) + "'");
+            return TR::TID_STR;
+        }
+        require_numeric(L, e.left->loc,  "'" + op + "' left operand");
+        require_numeric(R, e.right->loc, "'" + op + "' right operand");
+        return types_.unify(L, R);
+    }
+
+    // Comparison operators → bool
+    if (op == "==" || op == "!=" || op == "<" || op == ">" ||
+        op == "<=" || op == ">=" ) {
+        // Type compatibility is enforced loosely (warn, not error)
+        if (L != TR::TID_UNKNOWN && R != TR::TID_UNKNOWN &&
+            !types_.assignable(L, R) && !types_.assignable(R, L))
+            warn(e.loc, "comparing '" + types_.name_of(L) + "' with '" +
+                        types_.name_of(R) + "'");
+        return TR::TID_BOOL;
+    }
+
+    // Logical operators → bool
+    if (op == "&&" || op == "||") {
+        require_bool(L, e.left->loc,  "'" + op + "' left operand");
+        require_bool(R, e.right->loc, "'" + op + "' right operand");
+        return TR::TID_BOOL;
+    }
+
+    // Range operators → object (range type)
+    if (op == "..<" || op == "..=") {
+        require_numeric(L, e.left->loc,  "range start");
+        require_numeric(R, e.right->loc, "range end");
+        return TR::TID_OBJECT; // range type — will be refined in M4
+    }
+
+    return TR::TID_UNKNOWN;
+}
+
+TypeId Sema::check_unary(const ast::UnaryExpr& e) {
+    TypeId t = check_expr(*e.operand);
+    const std::string& op = e.op;
+
+    if (op == "!" || op == "not") {
+        require_bool(t, e.operand->loc, "'" + op + "' operand");
+        return TR::TID_BOOL;
+    }
+    if (op == "-" || op == "+") {
+        require_numeric(t, e.operand->loc, "'" + op + "' operand");
+        return t;
+    }
+    if (op == "~") {
+        if (!types_.is_integral(t) && t != TR::TID_UNKNOWN)
+            err(e.operand->loc, "'~' requires integral operand, got '" + types_.name_of(t) + "'");
+        return t;
+    }
+    if (op == "++" || op == "--") {
+        require_numeric(t, e.operand->loc, "'" + op + "' operand");
+        return t;
+    }
+    return t;
+}
+
+TypeId Sema::check_call(const ast::CallExpr& e) {
+    // Try to resolve callee to a symbol to check args.
+    Symbol* sym = nullptr;
+
+    if (auto* id = dynamic_cast<const ast::IdentExpr*>(e.callee.get())) {
+        sym = scopes_.lookup(id->name);
+        if (!sym) {
+            err(id->loc, "undefined function '" + id->name + "'");
+            // still check arg expressions
+            for (const auto& a : e.args) check_expr(*a);
+            return TR::TID_UNKNOWN;
+        }
+        id->type_id = sym->type;
+    } else {
+        // Member call or complex expression — check callee, skip signature check
+        TypeId callee_t = check_expr(*e.callee);
+        (void)callee_t;
+        for (const auto& a : e.args) check_expr(*a);
+        return TR::TID_UNKNOWN;
+    }
+
+    // Check argument count
+    if (sym->kind == SymKind::Function || sym->kind == SymKind::BuiltIn) {
+        if (!sym->params.empty() &&
+            sym->params.size() != e.args.size()) {
+            std::ostringstream os;
+            os << "'" << sym->name << "' expects " << sym->params.size()
+               << " argument(s), got " << e.args.size();
+            err(e.loc, os.str());
+        }
+        // Check each argument type
+        for (std::size_t i = 0; i < e.args.size(); ++i) {
+            TypeId at = check_expr(*e.args[i]);
+            if (i < sym->params.size()) {
+                require_assignable(at, sym->params[i].second,
+                    e.args[i]->loc,
+                    "argument " + std::to_string(i + 1) + " to '" + sym->name + "'");
+            }
+        }
+        return sym->return_type;
+    }
+
+    // Class constructor call
+    if (sym->kind == SymKind::Class) {
+        for (const auto& a : e.args) check_expr(*a);
+        return sym->type;
+    }
+
+    for (const auto& a : e.args) check_expr(*a);
+    return TR::TID_UNKNOWN;
+}
+
+TypeId Sema::check_member(const ast::MemberExpr& e) {
+    TypeId obj_t = check_expr(*e.object);
+
+    // Try to find the member in the class type info scope
+    if (obj_t != TR::TID_UNKNOWN && obj_t >= 0) {
+        // For now: if the object is a known class, allow any member access.
+        // Full field resolution would require per-class symbol tables (M3 work).
+    }
+    // Return unknown — type will be refined during codegen
+    return TR::TID_UNKNOWN;
+}
+
+TypeId Sema::check_index(const ast::IndexExpr& e) {
+    TypeId obj_t = check_expr(*e.object);
+    TypeId idx_t = check_expr(*e.index);
+
+    if (obj_t == TR::TID_LIST) {
+        if (!types_.is_integral(idx_t) && idx_t != TR::TID_UNKNOWN)
+            err(e.index->loc,
+                "list index must be integral, got '" + types_.name_of(idx_t) + "'");
+        return TR::TID_OBJECT;
+    }
+    if (obj_t == TR::TID_DICT) {
+        return TR::TID_OBJECT;
+    }
+    if (obj_t == TR::TID_STR) {
+        return TR::TID_STR;
+    }
+    return TR::TID_UNKNOWN;
+}
+
+TypeId Sema::check_new(const ast::NewExpr& e) {
+    TypeId t = type_from_te(e.type);
+    if (t == TR::TID_UNKNOWN) {
+        err(e.loc, "unknown type '" + e.type.name + "' in 'new'");
+    }
+    for (const auto& a : e.args) check_expr(*a);
+    return t;
+}
+
+TypeId Sema::check_list(const ast::ListExpr& e) {
+    for (const auto& elem : e.elements) check_expr(*elem);
+    return TR::TID_LIST;
+}
+
+TypeId Sema::check_dict(const ast::DictExpr& e) {
+    for (const auto& [k, v] : e.pairs) {
+        check_expr(*k);
+        check_expr(*v);
+    }
+    return TR::TID_DICT;
+}
+
+} // namespace dux::sema

--- a/src/sema/sema.hpp
+++ b/src/sema/sema.hpp
@@ -1,0 +1,83 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "ast/ast.hpp"
+#include "sema/types.hpp"
+#include "sema/symbol.hpp"
+
+class Driver;
+
+namespace dux::sema {
+
+class Sema {
+public:
+    explicit Sema(Driver& driver);
+
+    bool run(const ast::Program& prog);
+    int  error_count() const { return error_count_; }
+
+private:
+    Driver&      driver_;
+    TypeRegistry types_;
+    ScopeStack   scopes_;
+
+    TypeId      current_return_type_{TypeRegistry::TID_VOID};
+    std::string current_class_name_;
+    TypeId      current_class_type_{TypeRegistry::TID_UNKNOWN};
+    bool        in_loop_{false};
+    int         error_count_{0};
+
+    // ── Hoisting (pass 1) ──────────────────────────────────────────────────
+    void hoist_top(const ast::DeclList& decls);
+    void hoist_class(const ast::ClassDecl& c);
+    void hoist_interface(const ast::InterfaceDecl& i);
+    void hoist_namespace(const ast::NamespaceDecl& ns);
+
+    // ── Declarations (pass 2) ──────────────────────────────────────────────
+    void check_decl(const ast::Decl& d);
+    void check_func(const ast::FunctionDecl& f, TypeId class_type = TypeRegistry::TID_UNKNOWN);
+    void check_class(const ast::ClassDecl& c);
+    void check_interface(const ast::InterfaceDecl& i);
+    void check_namespace(const ast::NamespaceDecl& ns);
+    void check_import(const ast::ImportDecl& imp);
+
+    // ── Statements ────────────────────────────────────────────────────────
+    void check_stmts(const ast::StmtList& stmts);
+    void check_stmt(const ast::Stmt& s);
+    void check_block(const ast::BlockStmt& b);
+    void check_if(const ast::IfStmt& s);
+    void check_while(const ast::WhileStmt& s);
+    void check_do_while(const ast::DoWhileStmt& s);
+    void check_for_in(const ast::ForInStmt& s);
+    void check_for_c(const ast::ForCStmt& s);
+    void check_switch(const ast::SwitchStmt& s);
+    void check_try_catch(const ast::TryCatchStmt& s);
+    void check_return(const ast::ReturnStmt& s);
+    void check_var_decl(const ast::VarDeclStmt& s);
+    void check_assert(const ast::AssertStmt& s);
+    void check_delete(const ast::DeleteStmt& s);
+
+    // ── Expressions ───────────────────────────────────────────────────────
+    TypeId check_expr(const ast::Expr& e);
+    TypeId check_assign(const ast::AssignExpr& e);
+    TypeId check_binary(const ast::BinaryExpr& e);
+    TypeId check_unary(const ast::UnaryExpr& e);
+    TypeId check_call(const ast::CallExpr& e);
+    TypeId check_member(const ast::MemberExpr& e);
+    TypeId check_index(const ast::IndexExpr& e);
+    TypeId check_new(const ast::NewExpr& e);
+    TypeId check_list(const ast::ListExpr& e);
+    TypeId check_dict(const ast::DictExpr& e);
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+    TypeId type_from_te(const ast::TypeExpr& te) const;
+    bool   require_assignable(TypeId from, TypeId to,
+                              const ast::SourceLoc& loc, const std::string& ctx);
+    bool   require_numeric(TypeId t, const ast::SourceLoc& loc, const std::string& ctx);
+    bool   require_bool(TypeId t, const ast::SourceLoc& loc, const std::string& ctx);
+
+    void err(const ast::SourceLoc& loc, const std::string& msg);
+    void warn(const ast::SourceLoc& loc, const std::string& msg);
+};
+
+} // namespace dux::sema

--- a/src/sema/symbol.cpp
+++ b/src/sema/symbol.cpp
@@ -1,0 +1,55 @@
+#include "sema/symbol.hpp"
+
+namespace dux::sema {
+
+// ─── Scope ───────────────────────────────────────────────────────────────────
+
+bool Scope::define(const std::string& name, Symbol sym) {
+    auto [it, inserted] = symbols_.emplace(name, std::move(sym));
+    return inserted;
+}
+
+Symbol* Scope::lookup_local(const std::string& name) {
+    auto it = symbols_.find(name);
+    return it != symbols_.end() ? &it->second : nullptr;
+}
+
+const Symbol* Scope::lookup_local(const std::string& name) const {
+    auto it = symbols_.find(name);
+    return it != symbols_.end() ? &it->second : nullptr;
+}
+
+Symbol* Scope::lookup(const std::string& name) {
+    if (auto* s = lookup_local(name)) return s;
+    return parent_ ? parent_->lookup(name) : nullptr;
+}
+
+void Scope::for_each(
+    const std::function<void(const std::string&, const Symbol&)>& fn) const {
+    for (const auto& [k, v] : symbols_) fn(k, v);
+}
+
+// ─── ScopeStack ──────────────────────────────────────────────────────────────
+
+ScopeStack::ScopeStack() {
+    scopes_.push_back(std::make_unique<Scope>(nullptr, false));
+}
+
+void ScopeStack::push(bool is_class) {
+    scopes_.push_back(
+        std::make_unique<Scope>(scopes_.back().get(), is_class));
+}
+
+void ScopeStack::pop() {
+    if (scopes_.size() > 1) scopes_.pop_back();
+}
+
+bool ScopeStack::define(const std::string& name, Symbol sym) {
+    return scopes_.back()->define(name, std::move(sym));
+}
+
+Symbol* ScopeStack::lookup(const std::string& name) {
+    return scopes_.back()->lookup(name);
+}
+
+} // namespace dux::sema

--- a/src/sema/symbol.hpp
+++ b/src/sema/symbol.hpp
@@ -1,0 +1,66 @@
+#pragma once
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "ast/ast.hpp"
+#include "sema/types.hpp"
+
+namespace dux::sema {
+
+enum class SymKind { Var, Param, Function, Class, Interface, Namespace, BuiltIn };
+
+struct Symbol {
+    std::string  name;
+    SymKind      kind{SymKind::Var};
+    TypeId       type{TypeRegistry::TID_UNKNOWN};        // declared / inferred type
+    TypeId       return_type{TypeRegistry::TID_UNKNOWN}; // for functions
+    std::vector<std::pair<std::string, TypeId>> params;  // for functions
+    ast::Node*   decl{nullptr};  // non-owning back-pointer
+    ast::SourceLoc loc;
+    bool         is_const{false};
+};
+
+class Scope {
+public:
+    explicit Scope(Scope* parent = nullptr, bool is_class_scope = false)
+        : parent_(parent), is_class_(is_class_scope) {}
+
+    bool           define(const std::string& name, Symbol sym);
+    Symbol*        lookup_local(const std::string& name);
+    const Symbol*  lookup_local(const std::string& name) const;
+    Symbol*        lookup(const std::string& name);
+
+    Scope* parent()         const { return parent_; }
+    bool   is_class_scope() const { return is_class_; }
+
+    void for_each(const std::function<void(const std::string&, const Symbol&)>& fn) const;
+
+private:
+    Scope* parent_{nullptr};
+    bool   is_class_{false};
+    std::unordered_map<std::string, Symbol> symbols_;
+};
+
+class ScopeStack {
+public:
+    ScopeStack();  // creates and pre-populates the global scope
+
+    Scope& global_scope()  { return *scopes_.front(); }
+    Scope& current_scope() { return *scopes_.back();  }
+
+    void push(bool is_class = false);
+    void pop();
+
+    bool    define(const std::string& name, Symbol sym);
+    Symbol* lookup(const std::string& name);
+
+    std::size_t depth() const { return scopes_.size(); }
+
+private:
+    std::vector<std::unique_ptr<Scope>> scopes_;
+};
+
+} // namespace dux::sema

--- a/src/sema/types.cpp
+++ b/src/sema/types.cpp
@@ -1,0 +1,157 @@
+#include "sema/types.hpp"
+#include <stdexcept>
+
+namespace dux::sema {
+
+TypeRegistry::TypeRegistry() {
+    // Pre-allocate 12 built-in slots so indices match TID_* constants.
+    types_.resize(12);
+    add_builtin(TID_VOID,   TypeKind::Void,   "void",   -1);
+    add_builtin(TID_BOOL,   TypeKind::Bool,   "bool",   TID_OBJECT);
+    add_builtin(TID_INT,    TypeKind::Int,    "int",    TID_OBJECT);
+    add_builtin(TID_LONG,   TypeKind::Long,   "long",   TID_OBJECT);
+    add_builtin(TID_REAL,   TypeKind::Real,   "real",   TID_OBJECT);
+    add_builtin(TID_DOUBLE, TypeKind::Double, "double", TID_OBJECT);
+    add_builtin(TID_STR,    TypeKind::Str,    "str",    TID_OBJECT);
+    add_builtin(TID_LIST,   TypeKind::List,   "list",   TID_OBJECT);
+    add_builtin(TID_DICT,   TypeKind::Dict,   "dict",   TID_OBJECT);
+    add_builtin(TID_TUPLE,  TypeKind::Tuple,  "tuple",  TID_OBJECT);
+    add_builtin(TID_OBJECT, TypeKind::Object, "object", -1);
+    add_builtin(TID_NULL,   TypeKind::Null,   "null",   -1);
+}
+
+TypeId TypeRegistry::add_builtin(TypeId id, TypeKind kind,
+                                 const std::string& name, TypeId parent) {
+    TypeInfo& ti = types_[static_cast<std::size_t>(id)];
+    ti.kind   = kind;
+    ti.name   = name;
+    ti.parent = parent;
+    by_name_[name] = id;
+    return id;
+}
+
+TypeId TypeRegistry::intern(const std::string& name, TypeKind kind) {
+    auto it = by_name_.find(name);
+    if (it != by_name_.end()) return it->second;
+    TypeId id = static_cast<TypeId>(types_.size());
+    TypeInfo ti;
+    ti.kind   = kind;
+    ti.name   = name;
+    ti.parent = TID_OBJECT;
+    types_.push_back(std::move(ti));
+    by_name_[name] = id;
+    return id;
+}
+
+const TypeInfo& TypeRegistry::info(TypeId id) const {
+    if (id < 0 || id >= static_cast<TypeId>(types_.size()))
+        return types_[0]; // return void info as fallback
+    return types_[static_cast<std::size_t>(id)];
+}
+
+TypeInfo& TypeRegistry::info(TypeId id) {
+    if (id < 0 || id >= static_cast<TypeId>(types_.size()))
+        return types_[0];
+    return types_[static_cast<std::size_t>(id)];
+}
+
+TypeId TypeRegistry::from_name(const std::string& name) const {
+    auto it = by_name_.find(name);
+    return it != by_name_.end() ? it->second : TID_UNKNOWN;
+}
+
+TypeId TypeRegistry::from_type_expr(const ast::TypeExpr& te) const {
+    return from_name(te.name);
+}
+
+bool TypeRegistry::is_numeric(TypeId id) const {
+    return id == TID_INT || id == TID_LONG || id == TID_REAL ||
+           id == TID_DOUBLE || id == TID_BOOL;
+}
+
+bool TypeRegistry::is_integral(TypeId id) const {
+    return id == TID_INT || id == TID_LONG || id == TID_BOOL;
+}
+
+bool TypeRegistry::is_subtype(TypeId child, TypeId ancestor) const {
+    if (child == ancestor) return true;
+    if (ancestor == TID_OBJECT) return true;
+    if (child == TID_NULL)      return true;   // null fits any class slot
+    if (child  == TID_UNKNOWN || ancestor == TID_UNKNOWN) return true;
+
+    // Walk the parent chain
+    TypeId cur = child;
+    while (cur != TID_UNKNOWN && cur >= 0) {
+        if (cur == ancestor) return true;
+        const TypeInfo& ti = info(cur);
+        if (ti.parent == cur) break;  // avoid infinite loop
+        cur = ti.parent;
+    }
+    return false;
+}
+
+bool TypeRegistry::assignable(TypeId from, TypeId to) const {
+    if (from == TID_UNKNOWN || to == TID_UNKNOWN) return true;
+    if (from == to) return true;
+    if (to == TID_OBJECT) return true;
+    if (from == TID_NULL) {
+        // null is assignable to any class/interface/list/dict/str
+        const TypeInfo& ti = info(to);
+        return ti.kind == TypeKind::Class || ti.kind == TypeKind::Interface ||
+               to == TID_LIST || to == TID_DICT || to == TID_STR;
+    }
+    // Numeric widening
+    if (to == TID_DOUBLE) return is_numeric(from);
+    if (to == TID_REAL)   return from == TID_INT || from == TID_LONG ||
+                                 from == TID_BOOL || from == TID_REAL;
+    if (to == TID_LONG)   return from == TID_INT || from == TID_BOOL || from == TID_LONG;
+    if (to == TID_INT)    return from == TID_BOOL || from == TID_INT;
+
+    // Class subtyping
+    return is_subtype(from, to);
+}
+
+TypeId TypeRegistry::unify(TypeId a, TypeId b) const {
+    if (a == TID_UNKNOWN) return b;
+    if (b == TID_UNKNOWN) return a;
+    if (a == b)           return a;
+    if (a == TID_NULL)    return b;
+    if (b == TID_NULL)    return a;
+
+    // Numeric promotions
+    auto rank = [](TypeId t) -> int {
+        switch (t) {
+            case TID_BOOL:   return 1;
+            case TID_INT:    return 2;
+            case TID_LONG:   return 3;
+            case TID_REAL:   return 4;
+            case TID_DOUBLE: return 5;
+            default:         return 0;
+        }
+    };
+    int ra = rank(a), rb = rank(b);
+    if (ra > 0 && rb > 0) return ra >= rb ? a : b;
+
+    // Class hierarchy: find common ancestor
+    if (is_subtype(a, b)) return b;
+    if (is_subtype(b, a)) return a;
+    return TID_OBJECT;
+}
+
+void TypeRegistry::set_parent(TypeId child, TypeId parent) {
+    if (child >= 0 && child < static_cast<TypeId>(types_.size()))
+        types_[static_cast<std::size_t>(child)].parent = parent;
+}
+
+void TypeRegistry::add_interface(TypeId cls, TypeId iface) {
+    if (cls >= 0 && cls < static_cast<TypeId>(types_.size()))
+        types_[static_cast<std::size_t>(cls)].ifaces.push_back(iface);
+}
+
+std::string TypeRegistry::name_of(TypeId id) const {
+    if (id == TID_UNKNOWN) return "<unknown>";
+    if (id < 0 || id >= static_cast<TypeId>(types_.size())) return "<invalid>";
+    return types_[static_cast<std::size_t>(id)].name;
+}
+
+} // namespace dux::sema

--- a/src/sema/types.hpp
+++ b/src/sema/types.hpp
@@ -1,0 +1,73 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "ast/ast.hpp"
+
+namespace dux::sema {
+
+using TypeId = int32_t;
+
+enum class TypeKind {
+    Unknown, Void, Bool, Int, Long, Real, Double,
+    Str, List, Dict, Tuple, Object, Null,
+    Class, Interface, Function,
+};
+
+struct TypeInfo {
+    TypeKind    kind{TypeKind::Unknown};
+    std::string name;
+    TypeId      parent{-1};              // for class types
+    std::vector<TypeId> ifaces;          // implemented interfaces
+    TypeId      return_type{-1};         // for function types
+    std::vector<TypeId> param_types;     // for function types
+};
+
+class TypeRegistry {
+public:
+    static constexpr TypeId TID_UNKNOWN = -1;
+    static constexpr TypeId TID_VOID    =  0;
+    static constexpr TypeId TID_BOOL    =  1;
+    static constexpr TypeId TID_INT     =  2;
+    static constexpr TypeId TID_LONG    =  3;
+    static constexpr TypeId TID_REAL    =  4;
+    static constexpr TypeId TID_DOUBLE  =  5;
+    static constexpr TypeId TID_STR     =  6;
+    static constexpr TypeId TID_LIST    =  7;
+    static constexpr TypeId TID_DICT    =  8;
+    static constexpr TypeId TID_TUPLE   =  9;
+    static constexpr TypeId TID_OBJECT  = 10;
+    static constexpr TypeId TID_NULL    = 11;
+
+    TypeRegistry();
+
+    TypeId intern(const std::string& name, TypeKind kind = TypeKind::Class);
+
+    const TypeInfo& info(TypeId id) const;
+    TypeInfo&       info(TypeId id);
+
+    TypeId from_name(const std::string& name) const;
+    TypeId from_type_expr(const ast::TypeExpr& te) const;
+
+    bool   assignable(TypeId from, TypeId to) const;
+    TypeId unify(TypeId a, TypeId b) const;
+
+    bool is_numeric(TypeId id) const;
+    bool is_integral(TypeId id) const;
+    bool is_subtype(TypeId child, TypeId ancestor) const;
+
+    void set_parent(TypeId child, TypeId parent);
+    void add_interface(TypeId cls, TypeId iface);
+
+    std::string name_of(TypeId id) const;
+
+private:
+    std::vector<TypeInfo>              types_;
+    std::unordered_map<std::string, TypeId> by_name_;
+
+    TypeId add_builtin(TypeId id, TypeKind kind, const std::string& name,
+                       TypeId parent = TID_OBJECT);
+};
+
+} // namespace dux::sema

--- a/tests/sema_fail/break_outside_loop.dux
+++ b/tests/sema_fail/break_outside_loop.dux
@@ -1,0 +1,3 @@
+void main() {
+    break
+}

--- a/tests/sema_fail/continue_outside_loop.dux
+++ b/tests/sema_fail/continue_outside_loop.dux
@@ -1,0 +1,3 @@
+void main() {
+    continue
+}

--- a/tests/sema_fail/duplicate_function.dux
+++ b/tests/sema_fail/duplicate_function.dux
@@ -1,0 +1,11 @@
+int foo(int x) {
+    return x
+}
+
+int foo(int x) {
+    return x + 1
+}
+
+void main() {
+    println(foo(1))
+}

--- a/tests/sema_fail/new_unknown_type.dux
+++ b/tests/sema_fail/new_unknown_type.dux
@@ -1,0 +1,3 @@
+void main() {
+    x = new NonExistentClass(1, 2)
+}

--- a/tests/sema_fail/type_mismatch.dux
+++ b/tests/sema_fail/type_mismatch.dux
@@ -1,0 +1,3 @@
+void main() {
+    int x = "hello"
+}

--- a/tests/sema_fail/undefined_func.dux
+++ b/tests/sema_fail/undefined_func.dux
@@ -1,0 +1,3 @@
+void main() {
+    result = nonExistentFunction(1, 2)
+}

--- a/tests/sema_fail/undefined_var.dux
+++ b/tests/sema_fail/undefined_var.dux
@@ -1,0 +1,3 @@
+void main() {
+    println(undeclaredVariable)
+}

--- a/tests/sema_fail/wrong_arg_count.dux
+++ b/tests/sema_fail/wrong_arg_count.dux
@@ -1,0 +1,7 @@
+int add(int a, int b) {
+    return a + b
+}
+
+void main() {
+    r = add(1, 2, 3)
+}

--- a/tests/sema_ok/arithmetic.dux
+++ b/tests/sema_ok/arithmetic.dux
@@ -1,0 +1,14 @@
+void main() {
+    int a = 10
+    int b = 3
+    int sum  = a + b
+    int diff = a - b
+    int prod = a * b
+    int quot = a / b
+    int rem  = a % b
+    println(sum)
+    println(diff)
+    println(prod)
+    println(quot)
+    println(rem)
+}

--- a/tests/sema_ok/classes.dux
+++ b/tests/sema_ok/classes.dux
@@ -1,0 +1,30 @@
+class Point {
+    int x
+    int y
+
+    Point(int x, int y) {
+        this.x = x
+        this.y = y
+    }
+
+    int getX() {
+        return this.x
+    }
+
+    int getY() {
+        return this.y
+    }
+
+    str toString() {
+        return "Point"
+    }
+}
+
+void main() {
+    p = new Point(3, 4)
+    px = p.getX()
+    py = p.getY()
+    println(px)
+    println(py)
+    delete p
+}

--- a/tests/sema_ok/collections.dux
+++ b/tests/sema_ok/collections.dux
@@ -1,0 +1,10 @@
+void main() {
+    list nums = [1, 2, 3, 4, 5]
+    println(len(nums))
+
+    dict person = {'name': "Alice", 'age': 30}
+    println(person['name'])
+
+    first = nums[0]
+    println(first)
+}

--- a/tests/sema_ok/const_vars.dux
+++ b/tests/sema_ok/const_vars.dux
@@ -1,0 +1,9 @@
+void main() {
+    const int MAX = 100
+    const str GREETING = "Hello"
+    const bool DEBUG = false
+
+    println(MAX)
+    println(GREETING)
+    println(DEBUG)
+}

--- a/tests/sema_ok/control_flow.dux
+++ b/tests/sema_ok/control_flow.dux
@@ -1,0 +1,23 @@
+void main() {
+    int x = 10
+
+    if x > 5 {
+        println("big")
+    } else {
+        println("small")
+    }
+
+    int i = 0
+    while i < 5 {
+        println(i)
+        i = i + 1
+    }
+
+    for int j in 0..<5 {
+        println(j)
+    }
+
+    do {
+        i = i - 1
+    } while i > 0
+}

--- a/tests/sema_ok/functions.dux
+++ b/tests/sema_ok/functions.dux
@@ -1,0 +1,21 @@
+int add(int a, int b) {
+    return a + b
+}
+
+str repeat(str s, int n) {
+    result = s
+    return result
+}
+
+bool isPositive(int x) {
+    return x > 0
+}
+
+void main() {
+    int r = add(3, 4)
+    str t = repeat("ha", 3)
+    bool pos = isPositive(5)
+    println(r)
+    println(t)
+    println(pos)
+}

--- a/tests/sema_ok/hello.dux
+++ b/tests/sema_ok/hello.dux
@@ -1,0 +1,3 @@
+void main() {
+    println("Hello World!")
+}

--- a/tests/sema_ok/inheritance.dux
+++ b/tests/sema_ok/inheritance.dux
@@ -1,0 +1,39 @@
+class Animal {
+    str name
+
+    Animal(str name) {
+        this.name = name
+    }
+
+    str getName() {
+        return this.name
+    }
+
+    str speak() {
+        return "..."
+    }
+}
+
+class Dog(Animal) {
+    str breed
+
+    Dog(str name, str breed) {
+        this.name  = name
+        this.breed = breed
+    }
+
+    str speak() {
+        return "Woof"
+    }
+
+    str getBreed() {
+        return this.breed
+    }
+}
+
+void main() {
+    d = new Dog("Rex", "Labrador")
+    println(d.getName())
+    println(d.speak())
+    delete d
+}

--- a/tests/sema_ok/loop_break_continue.dux
+++ b/tests/sema_ok/loop_break_continue.dux
@@ -1,0 +1,11 @@
+void main() {
+    for int i in 0..<10 {
+        if i == 5 {
+            break
+        }
+        if i == 3 {
+            continue
+        }
+        println(i)
+    }
+}

--- a/tests/sema_ok/namespaces.dux
+++ b/tests/sema_ok/namespaces.dux
@@ -1,0 +1,16 @@
+namespace math {
+    int square(int x) {
+        return x * x
+    }
+
+    int cube(int x) {
+        return x * x * x
+    }
+}
+
+void main() {
+    int s = math.square(5)
+    int c = math.cube(3)
+    println(s)
+    println(c)
+}

--- a/tests/sema_ok/string_ops.dux
+++ b/tests/sema_ok/string_ops.dux
@@ -1,0 +1,14 @@
+str greet(str name) {
+    return "Hello, " + name
+}
+
+void main() {
+    str msg = greet("World")
+    println(msg)
+    println(len(msg))
+
+    str a = "foo"
+    str b = "bar"
+    str ab = a + b
+    println(ab)
+}

--- a/tests/sema_ok/switch_stmt.dux
+++ b/tests/sema_ok/switch_stmt.dux
@@ -1,0 +1,16 @@
+void describe(int x) {
+    switch x {
+        case 1:
+            println("one")
+        case 2:
+            println("two")
+        default:
+            println("other")
+    }
+}
+
+void main() {
+    describe(1)
+    describe(2)
+    describe(99)
+}

--- a/tests/sema_ok/try_catch.dux
+++ b/tests/sema_ok/try_catch.dux
@@ -1,0 +1,17 @@
+void risky() {
+    println("risky operation")
+}
+
+void main() {
+    try {
+        risky()
+    } catch ... {
+        println("caught")
+    }
+
+    try {
+        risky()
+    } catch(Exception e) {
+        println(e)
+    }
+}

--- a/tests/sema_ok/variables.dux
+++ b/tests/sema_ok/variables.dux
@@ -1,0 +1,13 @@
+# Explicit typed declarations and implicit assignments
+void main() {
+    int x = 5
+    str msg = "hello"
+    bool flag = true
+    double pi = 3.14159
+
+    # implicit assignment (type inferred from rhs)
+    y = x + 1
+    greeting = msg + " world"
+    println(y)
+    println(greeting)
+}


### PR DESCRIPTION
…ype checking

Implements GitHub issues #5–#12 (M2 — Semantic Analysis milestone):

  #5  Symbol table: Scope, ScopeStack with lexical nesting
  #6  Name resolution: two-pass (hoist declarations, then resolve uses)
  #7  Type system: TypeRegistry with 12 built-in types, widening rules,
      subtype chain, assignability, unification
  #8  Type inference: propagate initialiser type when annotation is omitted
  #9  Expression type checking: literals, binary/unary ops, comparisons,
      string concat, range ops, logical ops
  #10 Function call checking: argument count and type validation,
      return-type propagation
  #11 Class/interface hierarchy: base class wiring, member hoisting,
      this/super bindings
  #12 Import resolution: simplified (registers top-level module name)

New files:
  src/sema/types.hpp / types.cpp   — TypeId, TypeKind, TypeInfo, TypeRegistry
  src/sema/symbol.hpp / symbol.cpp — Symbol, Scope, ScopeStack
  src/sema/sema.hpp / sema.cpp     — Sema visitor (check_* methods)

Added --check CLI flag: runs sema after parsing, exits non-zero on errors. Diagnostics are clang-style (file:line:col: error: msg with caret). Added mutable type_id annotation field to ast::Expr for codegen use.

New tests (22): tests/sema_ok/ (14) + tests/sema_fail/ (8)
Total CTest suite: 59 tests, 100% passing.