### PR TITLE
refactor(codegen): eliminate duplication and fix latent bugs found in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # Dux Lang
 
-An experimental compiled programming language that fuses Python's elegance with C++'s strength — without the crazy syntax.
+An experimental compiled programming language that fuses Python's elegance with C++'s
+strength — statically typed, compiles to native code via LLVM IR.
 
-## Goals
+## Status
 
-- Clean, readable syntax with optional semicolons (Go-style automatic insertion)
-- Static typing with type inference
-- Classes, interfaces, decorators, destructors, and constructor init-lists
-- Compiled via a hand-written Flex/Bison front-end targeting C++ back-end
+**M6 — Complete** · 80/80 tests passing · `examples/design.dux` and `examples/euler12.dux`
+compile and run end-to-end.
+
+| Milestone | Feature |
+|-----------|---------|
+| M1 | Flex/Bison lexer + parser |
+| M2 | Semantic analysis, type system, symbol table |
+| M3 | LLVM IR code generation |
+| M4 | Runtime library (duxrt) + native compilation |
+| M5 | Stdlib imports (`math`), optimisation pipeline, DWARF debug info |
+| M6 | Integration tests, language spec, stdlib docs |
 
 ## Requirements
 
@@ -17,10 +25,11 @@ An experimental compiled programming language that fuses Python's elegance with 
 | C++ compiler | C++23 (GCC 13+ or Clang 16+) |
 | Flex | ≥ 2.6 |
 | Bison | ≥ 3.8 |
+| LLVM | 18 |
 
 ```bash
 # Ubuntu / Debian
-sudo apt install cmake flex bison g++-13
+sudo apt install cmake flex bison g++-13 llvm-18-dev
 ```
 
 ## Build
@@ -39,16 +48,33 @@ cmake --build build -j$(nproc)
 
 ## Usage
 
+```
+Usage: ./build/dux [options] [file]
+
+Options:
+  --dump-ast      Print the parsed AST to stdout
+  --check         Run semantic analysis and report errors
+  --emit-ir       Emit LLVM IR (to -o path or stdout)
+  --emit-obj      Emit native object file (requires -o path)
+  --compile       Compile to a runnable native executable
+  -o <path>       Output path
+  -O0/-O1/-O2/-O3 Optimisation level (default -O0)
+  -g              Emit DWARF debug information
+```
+
 ```bash
-# Parse a file and dump the AST
+# Compile and run a program
+./build/dux --compile examples/euler12.dux -O2 -o /tmp/euler12
+/tmp/euler12        # prints 842161320
+
+# Dump AST
 ./build/dux --dump-ast examples/design.dux
 
-# Parse from stdin
-echo "void main() { println('hi') }" | ./build/dux --dump-ast
+# Emit LLVM IR
+./build/dux --emit-ir examples/euler12.dux
 
-# Debug flags
-./build/dux --trace-lex   examples/hello_world.dux   # flex token trace
-./build/dux --trace-parse examples/hello_world.dux   # bison state trace
+# Check for semantic errors only
+./build/dux --check examples/design.dux
 ```
 
 ## Run tests
@@ -60,59 +86,83 @@ cmake --build build && ctest --test-dir build --output-on-failure
 ## Language sample
 
 ```dux
-namespace com.example {
+import math
 
-    import dux.datetime.date
-
-    class Person(public object) {
-
-        public:
-
-        Person(str name, int age) {
-            this._name = name
-            this._age  = age
-        }
-
-        ~Person() {
-            delete this._hand
-        }
-
-        int burn_year() {
-            return date.today().year - this._age
-        }
-
-        private:
-        str _name
-        int _age
-    }
-
-    void main() {
-        Person p = new Person('Ada', 36)
-        println(p.burn_year())
-
-        for int i in 0..<10 {
-            println(i)
+int factorCount(long n) {
+    double square = math.sqrt(n)
+    int isquare = square
+    int count = 0
+    for long candidate in 1..=isquare {
+        if 0 == n % candidate {
+            if candidate * candidate == n {
+                count++
+            } else {
+                count += 2
+            }
         }
     }
+    return count
+}
+
+void main() {
+    long triangle = 1
+    int index = 1
+    while factorCount(triangle) < 1001 {
+        index++
+        triangle += index
+    }
+    println(triangle)   # 842161320
 }
 ```
+
+More examples in [`examples/`](examples/), including the full language showcase in
+[`examples/design.dux`](examples/design.dux).
+
+## Language features
+
+- **Types**: `int`, `long`, `real`, `double`, `bool`, `str`, `list`, `dict`, `tuple`
+- **Classes** with constructors, destructors, field defaults, inheritance, interfaces
+- **Namespaces** (dotted names; entry point auto-detected)
+- **Control flow**: `if/else`, `while`, `do/while`, `for … in` (range, `range(n)`, C-style), `switch`
+- **Labeled breaks/continues**: `&label while …` / `break &label`
+- **Exception handling**: `try { … } catch … { … }`
+- **Stdlib**: `import math` exposes `math.sqrt`, `math.sin`, etc. (LLVM intrinsics)
+- **Built-ins**: `println`, `range`, `assert`
+- **Optimisation**: `-O0` through `-O3` via LLVM `PassBuilder`
+- **Debug info**: `-g` emits DWARF via `DIBuilder`
+
+See [`docs/spec.md`](docs/spec.md) for the full language specification and
+[`docs/stdlib/math.md`](docs/stdlib/math.md) for the standard library API.
 
 ## Project layout
 
 ```
 src/
-  lexer/dux.l        — Flex lexer (ASI, string literals, range ops)
-  parser/dux.y       — Bison 3.8 LALR(1) grammar
-  ast/ast.hpp        — 35+ AST node types + Visitor interface
-  ast/ast.cpp        — accept() implementations
-  ast/printer.hpp    — AST pretty-printer
-  driver/driver.hpp  — Driver class (orchestrates parse)
-  driver/driver.cpp
-  main.cpp           — CLI entry point
+  lexer/dux.l         — Flex lexer (ASI, string literals, range ops)
+  parser/dux.y        — Bison 3.8 LALR(1) grammar
+  ast/ast.hpp         — 40+ AST node types + Visitor interface
+  ast/ast.cpp         — accept() implementations
+  ast/printer.hpp     — AST pretty-printer
+  driver/driver.hpp   — orchestrates parse → sema → codegen
+  sema/sema.cpp       — type checker, symbol resolution
+  sema/types.cpp      — TypeRegistry, subtyping, coercion rules
+  codegen/codegen.cpp — LLVM IR emitter
+  main.cpp            — CLI entry point
+runtime/
+  duxrt.c             — runtime library (println, list, dict, math shims)
 examples/
-  design.dux         — Full language showcase
-  hello_world.dux
-  euler12.dux
+  design.dux          — full language feature showcase
+  euler12.dux         — Project Euler #12 benchmark (842161320)
+tests/
+  run_ok/             — compile-and-run tests with golden output
+  sema_ok/            — sema tests expected to pass
+  sema_fail/          — sema tests expected to fail with errors
+  parse_ok/           — parser tests expected to pass
+  parse_fail/         — parser tests expected to fail
+  codegen_ok/         — IR emission tests
+docs/
+  spec.md             — language specification v0.1
+  stdlib/math.md      — math module API reference
 CMakeLists.txt
 ```
 

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -171,13 +171,8 @@ llvm::Type* Codegen::lower_type(TypeId tid) {
         case TR::TID_TUPLE:  return ptr_type();
         case TR::TID_OBJECT: return ptr_type();
         case TR::TID_NULL:   return ptr_type();
-        default: {
-            // User-defined class type → pointer to struct
-            const std::string& name = types_.name_of(tid);
-            if (!name.empty() && layouts_.count(name))
-                return ptr_type();
-            return ptr_type();
-        }
+        default:
+            return ptr_type(); // user-defined class types are heap-allocated
     }
 }
 
@@ -344,9 +339,9 @@ void Codegen::gen_func(const ast::FunctionDecl& f, const std::string& mangled,
     BasicBlock* entry = BasicBlock::Create(*ctx_, "entry", fn);
     builder_->SetInsertPoint(entry);
 
-    // DWARF: attach subprogram metadata
     debug_func(f, fn, mangled);
 
+    var_class_.clear(); // var→class map is local to each function body
     env_push();
 
     // If method: bind 'this'
@@ -438,9 +433,7 @@ void Codegen::emit_main_wrapper() {
     Function* user_main = mod_->getFunction("main");
     if (!user_main) {
         for (auto& f : *mod_) {
-            llvm::StringRef n = f.getName();
-            if ((n.ends_with("__main") || n == "main") &&
-                f.arg_size() == 0) {
+            if (f.getName().ends_with("__main") && f.arg_size() == 0) {
                 user_main = &f;
                 break;
             }
@@ -675,11 +668,8 @@ void Codegen::gen_stmt(const ast::Stmt& s) {
     if (auto* br = dynamic_cast<const ast::BreakStmt*>(&s)) {
         if (loop_stack_.empty()) return;
         if (br->label) {
-            for (int i = static_cast<int>(loop_stack_.size()) - 1; i >= 0; --i)
-                if (loop_stack_[static_cast<std::size_t>(i)].label == *br->label) {
-                    builder_->CreateBr(loop_stack_[static_cast<std::size_t>(i)].exit);
-                    return;
-                }
+            for (auto it = loop_stack_.rbegin(); it != loop_stack_.rend(); ++it)
+                if (it->label == *br->label) { builder_->CreateBr(it->exit); return; }
         }
         builder_->CreateBr(loop_stack_.back().exit);
         return;
@@ -687,11 +677,8 @@ void Codegen::gen_stmt(const ast::Stmt& s) {
     if (auto* co = dynamic_cast<const ast::ContinueStmt*>(&s)) {
         if (loop_stack_.empty()) return;
         if (co->label) {
-            for (int i = static_cast<int>(loop_stack_.size()) - 1; i >= 0; --i)
-                if (loop_stack_[static_cast<std::size_t>(i)].label == *co->label) {
-                    builder_->CreateBr(loop_stack_[static_cast<std::size_t>(i)].header);
-                    return;
-                }
+            for (auto it = loop_stack_.rbegin(); it != loop_stack_.rend(); ++it)
+                if (it->label == *co->label) { builder_->CreateBr(it->header); return; }
         }
         builder_->CreateBr(loop_stack_.back().header);
         return;
@@ -1336,18 +1323,8 @@ Value* Codegen::gen_call(const ast::CallExpr& e) {
         auto param_it = fn->arg_begin();
         for (const auto& a : e.args) {
             Value* v = gen_expr(*a);
-            if (param_it != fn->arg_end()) {
-                llvm::Type* pt = param_it->getType();
-                if (v->getType() != pt) {
-                    if (pt->isIntegerTy() && v->getType()->isIntegerTy())
-                        v = builder_->CreateIntCast(v, pt, true);
-                    else if (pt->isFloatingPointTy() && v->getType()->isIntegerTy())
-                        v = builder_->CreateSIToFP(v, pt);
-                    else if (pt->isIntegerTy() && v->getType()->isFloatingPointTy())
-                        v = builder_->CreateFPToSI(v, pt);
-                }
-                ++param_it;
-            }
+            if (param_it != fn->arg_end())
+                v = coerce_to_llvm_type(v, (param_it++)->getType());
             args.push_back(v);
         }
         return builder_->CreateCall(fn, args);
@@ -1359,33 +1336,17 @@ Value* Codegen::gen_call(const ast::CallExpr& e) {
         TypeId obj_tid = type_id_of(*mem->object);
         std::string cls_name = types_.name_of(obj_tid);
 
-        // Try direct (static) dispatch
+        // Use full class resolution (same fallback as gen_member / lvalue_of)
+        cls_name = resolve_class_name(*mem->object, obj_tid);
         std::string mangled = mangle(cls_name, mem->member);
         Function* fn = mod_->getFunction(mangled);
-        if (!fn && !cls_name.empty()) {
-            // Try resolving via var_class_ if not already tried
-            if (auto* id = dynamic_cast<const ast::IdentExpr*>(mem->object.get()))
-                if (var_class_.count(id->name))
-                    mangled = mangle(var_class_.at(id->name), mem->member);
-            fn = mod_->getFunction(mangled);
-        }
         if (fn) {
             std::vector<Value*> args = {obj};
             auto param_it = std::next(fn->arg_begin()); // skip 'this'
             for (const auto& a : e.args) {
                 Value* v = gen_expr(*a);
-                if (param_it != fn->arg_end()) {
-                    llvm::Type* pt = param_it->getType();
-                    if (v->getType() != pt) {
-                        if (pt->isIntegerTy() && v->getType()->isIntegerTy())
-                            v = builder_->CreateIntCast(v, pt, true);
-                        else if (pt->isFloatingPointTy() && v->getType()->isIntegerTy())
-                            v = builder_->CreateSIToFP(v, pt);
-                        else if (pt->isIntegerTy() && v->getType()->isFloatingPointTy())
-                            v = builder_->CreateFPToSI(v, pt);
-                    }
-                    ++param_it;
-                }
+                if (param_it != fn->arg_end())
+                    v = coerce_to_llvm_type(v, (param_it++)->getType());
                 args.push_back(v);
             }
             return builder_->CreateCall(fn, args);
@@ -1403,24 +1364,11 @@ Value* Codegen::gen_call(const ast::CallExpr& e) {
 
 Value* Codegen::gen_member(const ast::MemberExpr& e) {
     Value* obj = gen_expr(*e.object);
-    TypeId obj_tid = type_id_of(*e.object);
+    std::string cls_name = resolve_class_name(*e.object, type_id_of(*e.object));
 
-    // Resolve class name: prefer type registry lookup, fall back to 'this' context
-    std::string cls_name = types_.name_of(obj_tid);
-    if (!layouts_.count(cls_name)) {
-        // If object is 'this' or 'super', use current class
-        if (dynamic_cast<const ast::ThisExpr*>(e.object.get()) ||
-            dynamic_cast<const ast::SuperExpr*>(e.object.get()))
-            cls_name = current_class_;
-        // If object is an identifier, look up its class from the var→class map
-        if (!layouts_.count(cls_name)) {
-            if (auto* id = dynamic_cast<const ast::IdentExpr*>(e.object.get()))
-                cls_name = var_class_.count(id->name) ? var_class_.at(id->name) : "";
-        }
-    }
-
-    if (layouts_.count(cls_name)) {
-        const ClassLayout& layout = layouts_[cls_name];
+    auto layout_it = layouts_.find(cls_name);
+    if (layout_it != layouts_.end()) {
+        const ClassLayout& layout = layout_it->second;
         for (const auto& f : layout.fields) {
             if (f.name == e.member) {
                 Value* gep = builder_->CreateStructGEP(
@@ -1428,7 +1376,6 @@ Value* Codegen::gen_member(const ast::MemberExpr& e) {
                 return builder_->CreateLoad(lower_type(f.type), gep, e.member);
             }
         }
-        // Member is a method — return the function pointer
         for (const auto& mi : layout.methods) {
             if (mi.name == e.member && mi.fn)
                 return mi.fn;
@@ -1491,13 +1438,7 @@ Value* Codegen::gen_new(const ast::NewExpr& e) {
         if (fi.decl && fi.decl->init) {
             Value* gep = builder_->CreateStructGEP(st, raw, fi.index, fi.name + ".init");
             Value* init_val = gen_expr(*fi.decl->init.value());
-            llvm::Type* field_ty = lower_type(fi.type);
-            if (init_val->getType() != field_ty) {
-                if (field_ty->isIntegerTy() && init_val->getType()->isIntegerTy())
-                    init_val = builder_->CreateIntCast(init_val, field_ty, true);
-                else if (field_ty->isDoubleTy() && init_val->getType()->isIntegerTy())
-                    init_val = builder_->CreateSIToFP(init_val, field_ty);
-            }
+            init_val = coerce_to_llvm_type(init_val, lower_type(fi.type));
             builder_->CreateStore(init_val, gep);
         }
     }
@@ -1610,23 +1551,13 @@ Value* Codegen::lvalue_of(const ast::Expr& e) {
     }
     if (auto* mem = dynamic_cast<const ast::MemberExpr*>(&e)) {
         Value* obj = gen_expr(*mem->object);
-        TypeId obj_tid = type_id_of(*mem->object);
-        std::string cls_name = types_.name_of(obj_tid);
-        if (!layouts_.count(cls_name)) {
-            if (dynamic_cast<const ast::ThisExpr*>(mem->object.get()) ||
-                dynamic_cast<const ast::SuperExpr*>(mem->object.get()))
-                cls_name = current_class_;
-            if (!layouts_.count(cls_name)) {
-                if (auto* id = dynamic_cast<const ast::IdentExpr*>(mem->object.get()))
-                    cls_name = var_class_.count(id->name) ? var_class_.at(id->name) : "";
-            }
-        }
-        if (layouts_.count(cls_name)) {
-            const ClassLayout& layout = layouts_[cls_name];
-            for (const auto& f : layout.fields)
+        std::string cls_name = resolve_class_name(*mem->object, type_id_of(*mem->object));
+        auto it = layouts_.find(cls_name);
+        if (it != layouts_.end()) {
+            for (const auto& f : it->second.fields)
                 if (f.name == mem->member)
                     return builder_->CreateStructGEP(
-                        layout.struct_type, obj, f.index);
+                        it->second.struct_type, obj, f.index);
         }
         return nullptr;
     }
@@ -1661,6 +1592,33 @@ Value* Codegen::coerce(Value* val, TypeId from, TypeId to) {
     if (types_.is_integral(to) && val->getType() == llvm::Type::getInt1Ty(*ctx_))
         return builder_->CreateZExt(val, lower_type(to));
     return val;
+}
+
+Value* Codegen::coerce_to_llvm_type(Value* v, llvm::Type* pt) {
+    if (!pt || !v || v->getType() == pt) return v;
+    if (pt->isIntegerTy() && v->getType()->isIntegerTy())
+        return builder_->CreateIntCast(v, pt, true);
+    if (pt->isFloatingPointTy() && v->getType()->isIntegerTy())
+        return builder_->CreateSIToFP(v, pt);
+    if (pt->isIntegerTy() && v->getType()->isFloatingPointTy())
+        return builder_->CreateFPToSI(v, pt);
+    return v;
+}
+
+std::string Codegen::resolve_class_name(const ast::Expr& obj, TypeId obj_tid) const {
+    std::string cls = types_.name_of(obj_tid);
+    if (!layouts_.count(cls)) {
+        if (dynamic_cast<const ast::ThisExpr*>(&obj) ||
+            dynamic_cast<const ast::SuperExpr*>(&obj))
+            cls = current_class_;
+        if (!layouts_.count(cls)) {
+            if (auto* id = dynamic_cast<const ast::IdentExpr*>(&obj)) {
+                auto it = var_class_.find(id->name);
+                cls = (it != var_class_.end()) ? it->second : "";
+            }
+        }
+    }
+    return cls;
 }
 
 Value* Codegen::to_bool(Value* val, TypeId t) {

--- a/src/codegen/codegen.hpp
+++ b/src/codegen/codegen.hpp
@@ -211,7 +211,9 @@ private:
     llvm::Value* load_var(const std::string& name, const ast::SourceLoc& loc);
     llvm::Value* lvalue_of(const ast::Expr& e);
     llvm::Value* coerce(llvm::Value* val, TypeId from, TypeId to);
+    llvm::Value* coerce_to_llvm_type(llvm::Value* v, llvm::Type* target);
     llvm::Value* to_bool(llvm::Value* val, TypeId t);
+    std::string  resolve_class_name(const ast::Expr& obj, TypeId obj_tid) const;
 
     // Environment helpers
     void   env_push();
@@ -227,9 +229,6 @@ private:
 
     // Runtime call helpers (intrinsics / duxrt stubs)
     llvm::Value* rt_malloc(llvm::Value* size);
-    llvm::Value* rt_println_int(llvm::Value* v);
-    llvm::Value* rt_println_double(llvm::Value* v);
-    llvm::Value* rt_println_str(llvm::Value* v);
     llvm::Value* rt_println(llvm::Value* v, TypeId t);
     llvm::Function* get_or_declare_rt(const std::string& name,
                                       llvm::Type* ret,


### PR DESCRIPTION
… code review

Extract helpers to eliminate copy-paste:
- coerce_to_llvm_type(Value*, llvm::Type*): consolidates identical coercion logic that was duplicated in gen_call (plain + method paths) and gen_new field inits
- resolve_class_name(Expr&, TypeId): consolidates the this/super/var_class_ fallback chain that was duplicated verbatim in gen_member and lvalue_of; also unifies the partial copy in gen_call's method-call path

Bug fixes:
- gen_new field init coercion: isDoubleTy() → isFloatingPointTy() so 'real' fields with integer default values are correctly converted (was silently emitting bad IR)
- var_class_ cleared at gen_func entry: stale entries from a previous function body could cause member access to resolve against the wrong class layout
- layouts_ map: replace count()+[] double lookups with single find() calls in gen_member and lvalue_of

Minor cleanups:
- lower_type default branch: remove dead layouts_.count() check (both branches already returned ptr_type())
- emit_main_wrapper: remove redundant n == "main" in the fallback loop (already handled by mod_->getFunction("main") at the top)
- Labeled break/continue: replace C-style int loop + double static_cast with reverse iterators
- Remove unused rt_println_int/double/str declarations from codegen.hpp

docs: update README with M6 status, complete usage reference, feature list, project layout, and a real working code example

https://claude.ai/code/session_013268REeAo1j62C7yC5BB9P