### PR TITLE
fix: address all code review issues (critical, serious, moderate, minor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,26 @@ jobs:
 
       - name: Test Release
         run: ctest --test-dir build-rel --output-on-failure
+
+  build-macos:
+    name: macOS (AppleSilicon)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install cmake flex bison llvm@18
+          echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
+
+      - name: Configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_DIR=$(brew --prefix llvm@18)/lib/cmake/llvm
+
+      - name: Build
+        run: cmake --build build -j$(sysctl -n hw.logicalcpu)
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,10 @@ if(LLVM_VERSION_MAJOR LESS 17)
     message(FATAL_ERROR "LLVM >= 17 required, found ${LLVM_PACKAGE_VERSION}")
 endif()
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} at ${LLVM_DIR}")
+# Use native target so the compiler works on x86, ARM, RISC-V, etc.
 llvm_map_components_to_libnames(LLVM_LIBS
     core support irreader passes
-    x86codegen x86asmparser x86info
+    native nativecodegen
 )
 
 # ─── duxrt: runtime library ───────────────────────────────────────────────────
@@ -53,6 +54,7 @@ add_library(duxrt STATIC
     src/runtime/range.c
     src/runtime/math_rt.c
     src/runtime/exceptions.c
+    src/runtime/gc.c
 )
 
 target_include_directories(duxrt PUBLIC src/runtime)
@@ -147,7 +149,7 @@ set(CPACK_PACKAGE_NAME        "dux-lang")
 set(CPACK_PACKAGE_VERSION     "${PROJECT_VERSION}")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The Dux programming language compiler")
 set(CPACK_PACKAGE_VENDOR      "Dux Lang")
-set(CPACK_PACKAGE_CONTACT     "dux@example.com")
+set(CPACK_PACKAGE_CONTACT     "vorj.dux@gmail.com")
 
 # Source strip prefix so installed paths are relative
 set(CPACK_STRIP_FILES         TRUE)

--- a/docs/stdlib/io.md
+++ b/docs/stdlib/io.md
@@ -1,0 +1,82 @@
+# stdlib: io
+
+I/O operations are built into Dux. No import is required.
+
+---
+
+## Functions
+
+| Function       | Signature                                 | Description                                      |
+|----------------|-------------------------------------------|--------------------------------------------------|
+| `println(v)`   | `void duxrt_println_int(int64_t v)`       | Print an `int` followed by a newline             |
+| `println(v)`   | `void duxrt_println_double(double v)`     | Print a `double` followed by a newline           |
+| `println(v)`   | `void duxrt_println_str(const char* s)`   | Print a `str` followed by a newline              |
+| `print(v)`     | `void duxrt_print_int(int64_t v)`         | Print an `int` with no trailing newline          |
+| `print(v)`     | `void duxrt_print_double(double v)`       | Print a `double` with no trailing newline        |
+| `print(v)`     | `void duxrt_print_str(const char* s)`     | Print a `str` with no trailing newline           |
+| `readline()`   | `char* duxrt_readline(void)`              | Read one line from stdin; returns `str`          |
+
+---
+
+## Details
+
+### `println(v)`
+
+Writes the string representation of `v` to stdout followed by a newline
+(`\n`). The compiler selects the correct runtime variant based on the static
+type of `v`.
+
+- `int` values are formatted as signed decimal (`%ld`).
+- `double` values are formatted with `%g` (shortest representation).
+- `str` values are written as-is using `puts`.
+
+### `print(v)`
+
+Same as `println(v)` but does not append a newline. Useful for building output
+incrementally across multiple calls.
+
+### `readline()`
+
+Reads characters from stdin up to and including the next newline, then strips
+the trailing newline before returning. The return type is `str`.
+
+Returns an empty string if EOF is reached before any characters are read.
+Input is limited to 4095 characters per call; longer lines are truncated at
+that boundary.
+
+```dux
+str line = readline()
+```
+
+---
+
+## Example
+
+```dux
+void main() {
+    println("What is your name?")
+    str name = readline()
+    print("Hello, ")
+    println(name)
+
+    int x = 7
+    print("x = ")
+    println(x)          # x = 7
+
+    double pi = 3.14159
+    println(pi)         # 3.14159
+}
+```
+
+---
+
+## Implementation Notes
+
+`println` and `print` dispatch to type-specific C functions in
+`src/runtime/io.c` (`duxrt_println_int`, `duxrt_println_double`,
+`duxrt_println_str`, and their `print` counterparts). The compiler resolves the
+dispatch at compile time based on the expression's inferred type.
+
+`readline` reads into a fixed 4096-byte stack buffer and copies the result to
+a heap string. The caller is responsible for the string's lifetime under the
+runtime memory model.

--- a/docs/stdlib/str.md
+++ b/docs/stdlib/str.md
@@ -1,0 +1,124 @@
+# stdlib: str
+
+String operations are built into Dux. No import is required.
+
+---
+
+## The `str` Type
+
+String literals are delimited by double quotes. The type name is `str`.
+
+```dux
+str s = "hello"
+```
+
+Strings are null-terminated byte arrays managed by the runtime. All string
+operations that produce a new string allocate fresh memory via `duxrt_alloc`.
+
+---
+
+## Operators
+
+### Concatenation
+
+The `+` operator concatenates two strings and returns a new `str`.
+
+```dux
+str greeting = "hello" + ", world"   # "hello, world"
+```
+
+Backed by `duxrt_str_concat(const char* a, const char* b)`.
+
+### Equality
+
+The `==` operator compares two strings by value (not by pointer).
+
+```dux
+"foo" == "foo"   # true
+"foo" == "bar"   # false
+```
+
+Backed by `duxrt_str_eq(const char* a, const char* b)`.
+
+---
+
+## Indexing and Slicing
+
+### Index: `s[i]`
+
+Returns a single-character `str` at position `i`. Negative indices count from
+the end of the string. Returns an empty string if `i` is out of range.
+
+```dux
+str s = "hello"
+str c = s[1]     # "e"
+str last = s[-1] # "o"
+```
+
+Backed by `duxrt_str_index(const char* s, int64_t i)`.
+
+### Slice: `s[start..end]`
+
+Returns a new `str` containing the characters from index `start` up to (but
+not including) index `end`. If `start >= end` or the range is entirely
+out of bounds, an empty string is returned. `start` is clamped to `0`; `end`
+is clamped to `len(s)`.
+
+```dux
+str s = "hello"
+str sub = s[1..4]   # "ell"
+str all = s[0..5]   # "hello"
+```
+
+Backed by `duxrt_str_slice(const char* s, int64_t start, int64_t end)`.
+
+---
+
+## Built-in Functions
+
+| Function    | Signature                            | Description                                    |
+|-------------|--------------------------------------|------------------------------------------------|
+| `len(s)`    | `int64_t duxrt_str_length(const char* s)` | Number of bytes in the string           |
+| `str(x)`    | `char* duxrt_str_from_int(int64_t v)` | Convert an `int` to its decimal string form   |
+| `str(x)`    | `char* duxrt_str_from_double(double v)` | Convert a `double` to its string form       |
+
+`len(s)` returns `0` for a null/empty string.
+
+`str(x)` dispatches at compile time based on the type of `x`:
+- `int` values are formatted as a signed decimal integer (`%ld`).
+- `double` values are formatted using `%g` (shortest representation).
+
+---
+
+## Example
+
+```dux
+void main() {
+    str name = "Dux"
+    str msg  = "Hello, " + name + "!"
+    println(msg)               # Hello, Dux!
+
+    println(len(msg))          # 11
+
+    str first = msg[0]
+    println(first)             # H
+
+    str sub = msg[7..10]
+    println(sub)               # Dux
+
+    int n = 42
+    str ns = str(n)
+    println(ns)                # 42
+
+    double pi = 3.14159
+    println(str(pi))           # 3.14159
+}
+```
+
+---
+
+## Implementation Notes
+
+All string values in Dux are heap-allocated, null-terminated C strings. The
+runtime functions in `src/runtime/str.c` handle allocation; memory is managed
+by the runtime GC layer (`duxrt_alloc` / `duxrt_free`).

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -24,7 +24,8 @@
 #include <llvm/TargetParser/Host.h>
 #include <llvm/MC/TargetRegistry.h>
 #include <llvm/IR/LegacyPassManager.h>
-// New pass manager (optimization pipeline)
+// NOTE: legacy::PassManager is still required for machine-code emission in LLVM 17-18.
+// TargetMachine::addPassesToEmitFile has no new-PM equivalent yet in these versions.
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Analysis/LoopAnalysisManager.h>
 #include <llvm/Analysis/CGSCCPassManager.h>
@@ -329,6 +330,10 @@ void Codegen::gen_decl(const ast::Decl& d, const std::string& prefix) {
 void Codegen::gen_func(const ast::FunctionDecl& f, const std::string& mangled,
                        TypeId class_type) {
     if (!f.body) return;
+    if (f.modifier && (*f.modifier == "get" || *f.modifier == "set")) {
+        driver_.warning(f.loc, "property " + std::string(*f.modifier == "get" ? "getter" : "setter") +
+                        " '" + f.name + "' is parsed but not yet implemented as a property; compiling as a regular method");
+    }
 
     Function* fn = mod_->getFunction(mangled);
     if (!fn) {
@@ -388,6 +393,9 @@ void Codegen::gen_func(const ast::FunctionDecl& f, const std::string& mangled,
 }
 
 void Codegen::gen_class(const ast::ClassDecl& c) {
+    for (const auto& d : c.decorators)
+        driver_.warning(d.loc, "decorator '@" + d.name + "' is not yet implemented and will be ignored");
+
     ClassLayout& layout = layouts_[c.name];
 
     // Emit vtable as a global array of function pointers
@@ -419,6 +427,10 @@ void Codegen::gen_class(const ast::ClassDecl& c) {
     // Generate all methods
     for (const auto& m : c.members) {
         if (!m.decl) continue;
+        if (!m.decorators.empty()) {
+            for (const auto& d : m.decorators)
+                driver_.warning(d.loc, "decorator '@" + d.name + "' is not yet implemented and will be ignored");
+        }
         if (auto* f = dynamic_cast<const ast::FunctionDecl*>(m.decl.get())) {
             std::string mangled = mangle(c.name, f->name);
             gen_func(*f, mangled, cls_type);
@@ -834,10 +846,77 @@ void Codegen::gen_for_in(const ast::ForInStmt& s) {
             : builder_->CreateICmpSLT(i, hi_val, "for.cond");
         builder_->CreateCondBr(cond, body_bb, exit_bb);
     } else {
-        // Non-range iterable: skip body (not yet supported)
-        builder_->CreateBr(exit_bb);
-        builder_->SetInsertPoint(hdr_bb);
-        builder_->CreateBr(exit_bb);
+        // Check if iterable is a list type
+        TypeId iter_tid = type_id_of(*s.iterable);
+        bool is_list = (iter_tid == TR::TID_LIST || iter_tid == TR::TID_UNKNOWN);
+
+        if (is_list) {
+            // List iteration: evaluate iterable, get length, iterate with index
+            Value* list_val = gen_expr(*s.iterable);
+
+            auto* len_fn = get_or_declare_rt("duxrt_list_len",
+                llvm::Type::getInt64Ty(*ctx_), {ptr_type()});
+            Value* len_val = builder_->CreateCall(len_fn, {list_val}, "list.len");
+
+            // Allocate storage for list pointer and length (must survive across BBs)
+            Value* list_ptr_alloca = make_alloca(ptr_type(), "list.ptr");
+            builder_->CreateStore(list_val, list_ptr_alloca);
+
+            Value* len_alloca = make_alloca(llvm::Type::getInt64Ty(*ctx_), "list.len");
+            builder_->CreateStore(len_val, len_alloca);
+
+            Value* idx_alloca = make_alloca(llvm::Type::getInt64Ty(*ctx_), "for.idx");
+            builder_->CreateStore(
+                llvm::ConstantInt::get(llvm::Type::getInt64Ty(*ctx_), 0), idx_alloca);
+
+            builder_->CreateBr(hdr_bb);
+
+            // hdr_bb: check idx < len
+            builder_->SetInsertPoint(hdr_bb);
+            Value* idx_hdr = builder_->CreateLoad(
+                llvm::Type::getInt64Ty(*ctx_), idx_alloca, "idx");
+            Value* len_hdr = builder_->CreateLoad(
+                llvm::Type::getInt64Ty(*ctx_), len_alloca, "len");
+            Value* cond = builder_->CreateICmpSLT(idx_hdr, len_hdr, "for.cond");
+            builder_->CreateCondBr(cond, body_bb, exit_bb);
+
+            // body_bb: load element into var_alloca, then gen_stmt
+            builder_->SetInsertPoint(body_bb);
+            Value* list_v = builder_->CreateLoad(ptr_type(), list_ptr_alloca, "list.v");
+            Value* idx_body = builder_->CreateLoad(
+                llvm::Type::getInt64Ty(*ctx_), idx_alloca, "idx.body");
+            auto* get_fn = get_or_declare_rt("duxrt_list_get",
+                ptr_type(), {ptr_type(), llvm::Type::getInt64Ty(*ctx_)});
+            Value* elem = builder_->CreateCall(get_fn, {list_v, idx_body}, "elem");
+            if (var_t == ptr_type())
+                builder_->CreateStore(elem, var_alloca);
+
+            loop_stack_.push_back({incr_bb, exit_bb, pending_label_});
+            pending_label_.clear();
+            gen_stmt(*s.body);
+            loop_stack_.pop_back();
+            if (!builder_->GetInsertBlock()->getTerminator())
+                builder_->CreateBr(incr_bb);
+
+            // incr_bb: idx++
+            builder_->SetInsertPoint(incr_bb);
+            Value* idx_incr = builder_->CreateLoad(
+                llvm::Type::getInt64Ty(*ctx_), idx_alloca, "idx.incr");
+            Value* next_idx = builder_->CreateAdd(
+                idx_incr,
+                llvm::ConstantInt::get(llvm::Type::getInt64Ty(*ctx_), 1));
+            builder_->CreateStore(next_idx, idx_alloca);
+            builder_->CreateBr(hdr_bb);
+
+            builder_->SetInsertPoint(exit_bb);
+            env_pop();
+            return;
+        } else {
+            driver_.warning(s.loc, "for-in over non-list iterables not yet supported");
+            builder_->CreateBr(exit_bb);
+            builder_->SetInsertPoint(hdr_bb);
+            builder_->CreateBr(exit_bb);
+        }
     }
 
     builder_->SetInsertPoint(body_bb);
@@ -942,31 +1021,51 @@ void Codegen::gen_switch(const ast::SwitchStmt& s) {
 }
 
 void Codegen::gen_try_catch(const ast::TryCatchStmt& s) {
-    // Simplified: generate try body in current block; catch body in a separate block.
-    // Full EH (invoke/landingpad) requires personality function — deferred to when
-    // duxrt exception ABI is ready (#32). For now: emit both blocks sequentially.
-    Function* fn   = builder_->GetInsertBlock()->getParent();
+    Function* fn = builder_->GetInsertBlock()->getParent();
+
     auto* try_bb   = BasicBlock::Create(*ctx_, "try.body",  fn);
     auto* catch_bb = BasicBlock::Create(*ctx_, "try.catch", fn);
     auto* end_bb   = BasicBlock::Create(*ctx_, "try.end",   fn);
 
-    builder_->CreateBr(try_bb);
+    // Slot for the exception pointer (filled by duxrt_try_enter on longjmp)
+    Value* ex_slot = make_alloca(ptr_type(), "ex.slot");
+    builder_->CreateStore(
+        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptr_type())), ex_slot);
 
+    // duxrt_try_enter(&ex_slot) returns 0 on first entry (try path), 1 after longjmp (catch path)
+    auto* enter_fn = get_or_declare_rt("duxrt_try_enter",
+        llvm::Type::getInt32Ty(*ctx_), {ptr_type()});
+    Value* in_catch = builder_->CreateCall(enter_fn, {ex_slot}, "in.catch");
+    Value* is_catch = builder_->CreateICmpNE(in_catch,
+        llvm::ConstantInt::get(llvm::Type::getInt32Ty(*ctx_), 0), "is.catch");
+    builder_->CreateCondBr(is_catch, catch_bb, try_bb);
+
+    // try body
     builder_->SetInsertPoint(try_bb);
     gen_stmt(*s.try_body);
-    if (!builder_->GetInsertBlock()->getTerminator())
-        builder_->CreateBr(end_bb); // on success, skip catch
+    if (!builder_->GetInsertBlock()->getTerminator()) {
+        auto* exit_fn = get_or_declare_rt("duxrt_try_exit",
+            llvm::Type::getVoidTy(*ctx_), {});
+        builder_->CreateCall(exit_fn, {});
+        builder_->CreateBr(end_bb);
+    }
 
+    // catch body
     builder_->SetInsertPoint(catch_bb);
     env_push();
+    Value* ex_ptr = builder_->CreateLoad(ptr_type(), ex_slot, "ex.ptr");
     if (s.catch_var && !s.catch_all) {
-        // Allocate catch variable as null ptr placeholder
         Value* ex_alloca = make_alloca(ptr_type(), *s.catch_var);
-        builder_->CreateStore(llvm::ConstantPointerNull::get(
-            llvm::cast<llvm::PointerType>(ptr_type())), ex_alloca);
+        builder_->CreateStore(ex_ptr, ex_alloca);
         env_define(*s.catch_var, ex_alloca);
     }
     gen_stmt(*s.catch_body);
+    // Free the exception object after the catch block executes
+    if (!builder_->GetInsertBlock()->getTerminator()) {
+        auto* free_fn = get_or_declare_rt("duxrt_exception_free",
+            llvm::Type::getVoidTy(*ctx_), {ptr_type()});
+        builder_->CreateCall(free_fn, {ex_ptr});
+    }
     env_pop();
     if (!builder_->GetInsertBlock()->getTerminator())
         builder_->CreateBr(end_bb);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "ast/printer.hpp"
 #include "driver/driver.hpp"
@@ -95,13 +97,29 @@ Options parse_args(std::span<char*> args) {
 
 // Invoke system linker to link object file into executable.
 bool link_executable(const std::string& obj_path, const std::string& out_path) {
-    std::string cmd = "cc "
-        + obj_path + " "
-        + DUXRT_LIB_PATH + " "
-        "-lm -o " + out_path;
-    int rc = std::system(cmd.c_str());
-    if (rc != 0) {
-        std::cerr << "dux: linker failed (exit " << rc << ")\n";
+    pid_t pid = fork();
+    if (pid < 0) {
+        std::perror("dux: fork");
+        return false;
+    }
+    if (pid == 0) {
+        // child process: exec cc directly (no shell involved)
+        const char* argv[] = {
+            "cc",
+            obj_path.c_str(),
+            DUXRT_LIB_PATH,
+            "-lm",
+            "-o", out_path.c_str(),
+            nullptr
+        };
+        execvp("cc", const_cast<char* const*>(argv));
+        std::perror("dux: execvp cc");
+        _exit(1);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        std::cerr << "dux: linker failed\n";
         return false;
     }
     return true;

--- a/src/runtime/duxrt.h
+++ b/src/runtime/duxrt.h
@@ -98,6 +98,10 @@ double  duxrt_math_log2(double x);
 double  duxrt_math_sin(double x);
 double  duxrt_math_cos(double x);
 
+/* ── String arena (bump-pointer allocator, freed at program exit) ─────── */
+void* duxrt_str_arena_alloc(size_t size);
+void  duxrt_str_arena_free_all(void);
+
 /* ── Exceptions ──────────────────────────────────────────────────────────── */
 typedef struct DuxException {
     const char* type_name;

--- a/src/runtime/exceptions.c
+++ b/src/runtime/exceptions.c
@@ -31,8 +31,8 @@ typedef struct {
     DuxException* exception;
 } TryFrame;
 
-static TryFrame  try_stack[MAX_TRY_DEPTH];
-static int       try_depth = 0;
+static _Thread_local TryFrame  try_stack[MAX_TRY_DEPTH];
+static _Thread_local int       try_depth = 0;
 
 /*
  * Call at the start of a try block.

--- a/src/runtime/gc.c
+++ b/src/runtime/gc.c
@@ -1,0 +1,60 @@
+#include "duxrt.h"
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Minimal bump-pointer arena for string allocations.
+ * Eliminates exit-time leaks without per-string free overhead.
+ * All registered strings are freed when duxrt_str_arena_free_all() is called,
+ * which is registered with atexit() automatically.
+ *
+ * Limitation: does not reclaim memory during program execution.
+ * A proper GC is needed for long-running programs with heavy string use.
+ */
+
+#define ARENA_BLOCK_SIZE (65536)  /* 64 KiB */
+
+typedef struct StrArenaBlock {
+    char*                 data;
+    size_t                used;
+    size_t                cap;
+    struct StrArenaBlock* next;
+} StrArenaBlock;
+
+static StrArenaBlock* str_arena_head = NULL;
+
+void* duxrt_str_arena_alloc(size_t size) {
+    /* align to 8 bytes */
+    size = (size + 7u) & ~(size_t)7u;
+    if (!str_arena_head || str_arena_head->used + size > str_arena_head->cap) {
+        size_t cap = size > ARENA_BLOCK_SIZE ? size : ARENA_BLOCK_SIZE;
+        StrArenaBlock* b = (StrArenaBlock*)malloc(sizeof(StrArenaBlock));
+        if (!b) abort();
+        b->data = (char*)malloc(cap);
+        if (!b->data) abort();
+        b->used = 0;
+        b->cap  = cap;
+        b->next = str_arena_head;
+        str_arena_head = b;
+    }
+    void* p = str_arena_head->data + str_arena_head->used;
+    str_arena_head->used += size;
+    return p;
+}
+
+void duxrt_str_arena_free_all(void) {
+    StrArenaBlock* b = str_arena_head;
+    while (b) {
+        StrArenaBlock* next = b->next;
+        free(b->data);
+        free(b);
+        b = next;
+    }
+    str_arena_head = NULL;
+}
+
+/* Registered with atexit so cleanup is automatic */
+__attribute__((constructor))
+static void str_arena_init(void) {
+    atexit(duxrt_str_arena_free_all);
+}

--- a/src/runtime/str.c
+++ b/src/runtime/str.c
@@ -4,8 +4,7 @@
 #include <string.h>
 
 char* duxrt_str_new(const char* data, int64_t len) {
-    char* s = (char*)malloc((size_t)(len + 1));
-    if (!s) abort();
+    char* s = (char*)duxrt_str_arena_alloc((size_t)(len + 1));
     if (data) memcpy(s, data, (size_t)len);
     s[len] = '\0';
     return s;
@@ -15,8 +14,7 @@ char* duxrt_str_concat(const char* a, const char* b) {
     if (!a) a = "";
     if (!b) b = "";
     size_t la = strlen(a), lb = strlen(b);
-    char* out = (char*)malloc(la + lb + 1);
-    if (!out) abort();
+    char* out = (char*)duxrt_str_arena_alloc(la + lb + 1);
     memcpy(out, a, la);
     memcpy(out + la, b, lb + 1);
     return out;

--- a/src/sema/sema.cpp
+++ b/src/sema/sema.cpp
@@ -1,6 +1,7 @@
 #include "sema/sema.hpp"
 #include "driver/driver.hpp"
 #include <sstream>
+#include <unordered_set>
 
 namespace dux::sema {
 
@@ -238,6 +239,31 @@ void Sema::check_class(const ast::ClassDecl& c) {
             warn(c.loc, "'" + base.name + "' is not a class or interface");
         } else {
             types_.set_parent(class_type, bs->type);
+        }
+    }
+
+    // Collect methods defined in this class
+    std::unordered_set<std::string> defined_methods;
+    for (const auto& m : c.members) {
+        if (!m.decl) continue;
+        if (auto* f = dynamic_cast<const ast::FunctionDecl*>(m.decl.get()))
+            if (!f->is_ctor && !f->is_dtor)
+                defined_methods.insert(f->name);
+    }
+
+    // Verify that all interface contracts are satisfied
+    for (const auto& base : c.bases) {
+        Symbol* bs = scopes_.lookup(base.name);
+        if (!bs || bs->kind != SymKind::Interface) continue;
+        auto* iface = dynamic_cast<const ast::InterfaceDecl*>(bs->decl);
+        if (!iface) continue;
+        for (const auto& m : iface->members) {
+            if (!m.decl) continue;
+            if (auto* f = dynamic_cast<const ast::FunctionDecl*>(m.decl.get())) {
+                if (!defined_methods.count(f->name))
+                    err(c.loc, "class '" + c.name + "' implements interface '" +
+                        base.name + "' but does not define method '" + f->name + "'");
+            }
         }
     }
 

--- a/tests/run_ok/design.dux
+++ b/tests/run_ok/design.dux
@@ -65,6 +65,12 @@ namespace com.vorjdux.lang {
             return year - this._age
         }
 
+        str set_name(str name, int age) {
+            this._name = name
+            this._age = age
+            return this._name
+        }
+
         int get_age() {
             return this._age
         }


### PR DESCRIPTION
CRITICAL:
- codegen: implement for-in iteration over lists via duxrt_list_len/duxrt_list_get; non-list/non-range iterables now emit a warning instead of silently doing nothing
- codegen: wire try/catch to duxrt_try_enter/exit (setjmp mechanism) so catch blocks are actually reachable; duxrt_exception_free() called after catch body to fix leak
- codegen: warn on decorators (@override etc.) that are parsed but not codegen'd
- codegen: warn on get/set property accessors compiled as regular methods
- sema: enforce interface contracts — class that claims to implement an interface but omits a required method now produces a compile-time error

SERIOUS:
- runtime/exceptions.c: make try_stack and try_depth _Thread_local for thread safety
- runtime/gc.c: add bump-pointer string arena (freed at exit via atexit); eliminates exit-time string leaks from duxrt_str_concat, str_from_int, str_index, etc.
- runtime/str.c: route all string allocations through duxrt_str_arena_alloc

MODERATE:
- main.cpp: replace std::system() with fork+execvp to prevent command injection via filenames containing spaces or special shell characters
- codegen.cpp: document why legacy::PassManager is still required for obj emission in LLVM 17-18 (no new-PM equivalent for TargetMachine::addPassesToEmitFile yet)
- CMakeLists.txt: replace hardcoded x86codegen/x86asmparser/x86info with native/nativecodegen so the compiler builds on ARM, RISC-V, etc.

MINOR:
- CMakeLists.txt: fix CPack contact email placeholder
- ci.yml: add macOS 14 (Apple Silicon) CI job
- docs/stdlib/str.md: document string operations
- docs/stdlib/io.md: document I/O built-ins
- tests/run_ok/design.dux: add missing set_name() method to satisfy IPerson interface