### PR TITLE
fix(codegen): use actual LLVM types as fallback in binary type promotion

### DIFF
--- a/examples/01_basics/hello.dux
+++ b/examples/01_basics/hello.dux
@@ -1,0 +1,4 @@
+void main() {
+    println("Hello, World!")
+    println("Welcome to Dux.")
+}

--- a/examples/01_basics/operators.dux
+++ b/examples/01_basics/operators.dux
@@ -1,0 +1,56 @@
+void main() {
+    # ── Arithmetic ────────────────────────────────────────────────────────────
+    int a = 10
+    int b = 3
+    println(a + b)   # 13
+    println(a - b)   # 7
+    println(a * b)   # 30
+    println(a / b)   # 3  (integer division)
+    println(a % b)   # 1  (remainder)
+
+    # Floating-point division
+    double fa = 10.0
+    double fb = 3.0
+    println(fa / fb)  # 3.33333...
+
+    # Compound assignment
+    int n = 5
+    n = n + 1
+    println(n)   # 6
+
+    # ── Comparison (result used in if) ────────────────────────────────────────
+    if (a == 10) {
+        println("a equals 10")
+    }
+    if (a != b) {
+        println("a and b differ")
+    }
+    if (a > b) {
+        println("a is greater")
+    }
+    if (b < a) {
+        println("b is less")
+    }
+    if (a >= 10) {
+        println("a >= 10")
+    }
+    if (b <= 3) {
+        println("b <= 3")
+    }
+
+    # ── Logical ───────────────────────────────────────────────────────────────
+    int x = 5
+    if (x > 0 && x < 10) {
+        println("x is between 0 and 10")
+    }
+    if (x == 0 || x == 5) {
+        println("x is 0 or 5")
+    }
+    if (!0) {
+        println("not false is true")
+    }
+
+    # ── Unary ─────────────────────────────────────────────────────────────────
+    int neg = -a
+    println(neg)  # -10
+}

--- a/examples/01_basics/variables.dux
+++ b/examples/01_basics/variables.dux
@@ -1,0 +1,45 @@
+void main() {
+    # Integer types
+    int count = 0
+    int age = 25
+    count = count + 1
+    println(count)
+
+    # 64-bit integer
+    long big = 9000000000
+    println(big)
+
+    # Floating-point
+    double pi = 3.14159
+    double e  = 2.71828
+    println(pi)
+    println(e)
+
+    # Strings
+    str name  = "Dux"
+    str greet = "Hello, " + name + "!"
+    println(greet)
+
+    # Booleans — non-zero is truthy
+    int flag = 1
+    int off  = 0
+
+    if (flag) {
+        println("flag is true")
+    }
+    if (!off) {
+        println("off is false")
+    }
+
+    # Constants — value cannot be reassigned
+    const int MAX = 100
+    const str VERSION = "1.0.0"
+    println(MAX)
+    println(VERSION)
+
+    # Multiple assignments
+    int x = 10
+    int y = 20
+    int z = x + y
+    println(z)
+}

--- a/examples/02_strings/basics.dux
+++ b/examples/02_strings/basics.dux
@@ -1,0 +1,78 @@
+str int_to_str(int n) {
+    if (n == 0) {
+        return "0"
+    }
+    str result = ""
+    int neg = 0
+    if (n < 0) {
+        neg = 1
+        n = 0 - n
+    }
+    while (n > 0) {
+        int digit = n % 10
+        if (digit == 0) {
+            result = "0" + result
+        } else if (digit == 1) {
+            result = "1" + result
+        } else if (digit == 2) {
+            result = "2" + result
+        } else if (digit == 3) {
+            result = "3" + result
+        } else if (digit == 4) {
+            result = "4" + result
+        } else if (digit == 5) {
+            result = "5" + result
+        } else if (digit == 6) {
+            result = "6" + result
+        } else if (digit == 7) {
+            result = "7" + result
+        } else if (digit == 8) {
+            result = "8" + result
+        } else {
+            result = "9" + result
+        }
+        n = n / 10
+    }
+    if (neg == 1) {
+        result = "-" + result
+    }
+    return result
+}
+
+void main() {
+    # String literals
+    str s1 = "Hello"
+    str s2 = "World"
+
+    # Concatenation with +
+    str s3 = s1 + ", " + s2 + "!"
+    println(s3)          # Hello, World!
+
+    # Length
+    println(len(s3))     # 13
+
+    # Empty string
+    str empty = ""
+    println(len(empty))  # 0
+
+    # Equality
+    str a = "dux"
+    str b = "dux"
+    str c = "other"
+    if (a == b) {
+        println("equal")
+    }
+    if (a != c) {
+        println("not equal")
+    }
+
+    # Building strings from numbers using helper
+    int x = 42
+    double y = 3.14
+    str msg = "x=" + int_to_str(x)
+    println(msg)
+
+    # Single-quoted strings work too
+    str sq = 'single quotes'
+    println(sq)
+}

--- a/examples/02_strings/multiline.dux
+++ b/examples/02_strings/multiline.dux
@@ -1,0 +1,65 @@
+str int_to_str(int n) {
+    if (n == 0) {
+        return "0"
+    }
+    str result = ""
+    int neg = 0
+    if (n < 0) {
+        neg = 1
+        n = 0 - n
+    }
+    while (n > 0) {
+        int digit = n % 10
+        if (digit == 0) {
+            result = "0" + result
+        } else if (digit == 1) {
+            result = "1" + result
+        } else if (digit == 2) {
+            result = "2" + result
+        } else if (digit == 3) {
+            result = "3" + result
+        } else if (digit == 4) {
+            result = "4" + result
+        } else if (digit == 5) {
+            result = "5" + result
+        } else if (digit == 6) {
+            result = "6" + result
+        } else if (digit == 7) {
+            result = "7" + result
+        } else if (digit == 8) {
+            result = "8" + result
+        } else {
+            result = "9" + result
+        }
+        n = n / 10
+    }
+    if (neg == 1) {
+        result = "-" + result
+    }
+    return result
+}
+
+void main() {
+    # Strings can be formed by concatenating across multiple lines
+    str poem = "Roses are red,\n" +
+               "Violets are blue,\n" +
+               "Dux is fast,\n" +
+               "And memory-safe too."
+    println(poem)
+
+    # Escape sequences
+    str tab_sep = "col1\tcol2\tcol3"
+    println(tab_sep)
+
+    str with_quotes = "She said \"hello\""
+    println(with_quotes)
+
+    # Building long strings incrementally
+    str result = ""
+    int i = 1
+    while (i <= 5) {
+        result = result + int_to_str(i) + " "
+        i = i + 1
+    }
+    println(result)   # 1 2 3 4 5
+}

--- a/examples/02_strings/operations.dux
+++ b/examples/02_strings/operations.dux
@@ -1,0 +1,79 @@
+str int_to_str(int n) {
+    if (n == 0) {
+        return "0"
+    }
+    str result = ""
+    int neg = 0
+    if (n < 0) {
+        neg = 1
+        n = 0 - n
+    }
+    while (n > 0) {
+        int digit = n % 10
+        if (digit == 0) {
+            result = "0" + result
+        } else if (digit == 1) {
+            result = "1" + result
+        } else if (digit == 2) {
+            result = "2" + result
+        } else if (digit == 3) {
+            result = "3" + result
+        } else if (digit == 4) {
+            result = "4" + result
+        } else if (digit == 5) {
+            result = "5" + result
+        } else if (digit == 6) {
+            result = "6" + result
+        } else if (digit == 7) {
+            result = "7" + result
+        } else if (digit == 8) {
+            result = "8" + result
+        } else {
+            result = "9" + result
+        }
+        n = n / 10
+    }
+    if (neg == 1) {
+        result = "-" + result
+    }
+    return result
+}
+
+void main() {
+    str text = "Hello, Dux!"
+
+    # Length
+    println(len(text))          # 11
+
+    # Index — returns a single-character string
+    str first = text[0]
+    str last  = text[-1]        # negative index from end
+    println(first)              # H
+    println(last)               # !
+
+    # Slice — extract a substring by iterating characters
+    str word = ""
+    int i = 7
+    while (i < 10) {
+        word = word + text[i]
+        i = i + 1
+    }
+    println(word)               # Dux
+
+    # Concatenation builds new strings
+    str a = "foo"
+    str b = "bar"
+    str c = a + b
+    println(c)                  # foobar
+
+    # Numbers to strings using int_to_str helper
+    println(int_to_str(123))    # 123
+
+    # Iterating over characters with a while loop
+    str chars = "Dux"
+    int j = 0
+    while (j < len(chars)) {
+        println(chars[j])       # D, u, x (one per line)
+        j = j + 1
+    }
+}

--- a/examples/03_control_flow/for_range.dux
+++ b/examples/03_control_flow/for_range.dux
@@ -1,0 +1,82 @@
+str int_to_str(int n) {
+    if (n == 0) {
+        return "0"
+    }
+    str result = ""
+    int neg = 0
+    if (n < 0) {
+        neg = 1
+        n = 0 - n
+    }
+    while (n > 0) {
+        int digit = n % 10
+        if (digit == 0) {
+            result = "0" + result
+        } else if (digit == 1) {
+            result = "1" + result
+        } else if (digit == 2) {
+            result = "2" + result
+        } else if (digit == 3) {
+            result = "3" + result
+        } else if (digit == 4) {
+            result = "4" + result
+        } else if (digit == 5) {
+            result = "5" + result
+        } else if (digit == 6) {
+            result = "6" + result
+        } else if (digit == 7) {
+            result = "7" + result
+        } else if (digit == 8) {
+            result = "8" + result
+        } else {
+            result = "9" + result
+        }
+        n = n / 10
+    }
+    if (neg == 1) {
+        result = "-" + result
+    }
+    return result
+}
+
+void main() {
+    # Exclusive range  ..<  (does not include end)
+    for int i in 0..<5 {
+        println(i)   # 0 1 2 3 4
+    }
+
+    # Inclusive range  ..=  (includes end)
+    for int i in 1..=5 {
+        println(i)   # 1 2 3 4 5
+    }
+
+    # range(n) shorthand  →  0..<n
+    for int i in range(3) {
+        println(i)   # 0 1 2
+    }
+
+    # Sum with for-range
+    int total = 0
+    for int i in 1..=10 {
+        total = total + i
+    }
+    println(total)   # 55
+
+    # Nested ranges — multiplication table 1..5
+    for int row in 1..=5 {
+        str line = ""
+        for int col in 1..=5 {
+            int product = row * col
+            line = line + int_to_str(product) + " "
+        }
+        println(line)
+    }
+
+    # Decrement: loop variable can be decremented manually
+    int k = 10
+    for int i in 0..<5 {
+        println(k)
+        k = k - 2
+    }
+    # Output: 10 8 6 4 2
+}

--- a/examples/03_control_flow/if_else.dux
+++ b/examples/03_control_flow/if_else.dux
@@ -1,0 +1,90 @@
+str int_to_str(int n) {
+    if (n == 0) {
+        return "0"
+    }
+    str result = ""
+    int neg = 0
+    if (n < 0) {
+        neg = 1
+        n = 0 - n
+    }
+    while (n > 0) {
+        int digit = n % 10
+        if (digit == 0) {
+            result = "0" + result
+        } else if (digit == 1) {
+            result = "1" + result
+        } else if (digit == 2) {
+            result = "2" + result
+        } else if (digit == 3) {
+            result = "3" + result
+        } else if (digit == 4) {
+            result = "4" + result
+        } else if (digit == 5) {
+            result = "5" + result
+        } else if (digit == 6) {
+            result = "6" + result
+        } else if (digit == 7) {
+            result = "7" + result
+        } else if (digit == 8) {
+            result = "8" + result
+        } else {
+            result = "9" + result
+        }
+        n = n / 10
+    }
+    if (neg == 1) {
+        result = "-" + result
+    }
+    return result
+}
+
+str classify(int n) {
+    if (n < 0) {
+        return "negative"
+    } else if (n == 0) {
+        return "zero"
+    } else if (n < 10) {
+        return "small"
+    } else {
+        return "large"
+    }
+}
+
+str fizzbuzz(int n) {
+    if (n % 15 == 0) {
+        return "FizzBuzz"
+    } else if (n % 3 == 0) {
+        return "Fizz"
+    } else if (n % 5 == 0) {
+        return "Buzz"
+    } else {
+        return int_to_str(n)
+    }
+}
+
+void main() {
+    # Basic if / else if / else
+    println(classify(-5))   # negative
+    println(classify(0))    # zero
+    println(classify(7))    # small
+    println(classify(42))   # large
+
+    # Nested conditions
+    int x = 15
+    int y = 20
+    if (x > 10) {
+        if (y > 15) {
+            println("both large")
+        } else {
+            println("only x large")
+        }
+    }
+
+    # FizzBuzz 1..15
+    int i = 1
+    while (i <= 15) {
+        println(fizzbuzz(i))
+        i = i + 1
+    }
+}

--- a/examples/03_control_flow/switch.dux
+++ b/examples/03_control_flow/switch.dux
@@ -1,0 +1,46 @@
+str day_name(int d) {
+    switch (d) {
+        case 1: return "Monday"
+        case 2: return "Tuesday"
+        case 3: return "Wednesday"
+        case 4: return "Thursday"
+        case 5: return "Friday"
+        case 6: return "Saturday"
+        case 7: return "Sunday"
+        default: return "unknown"
+    }
+}
+
+str season(int month) {
+    switch (month) {
+        case 12:
+        case 1:
+        case 2:
+            return "Winter"
+        case 3:
+        case 4:
+        case 5:
+            return "Spring"
+        case 6:
+        case 7:
+        case 8:
+            return "Summer"
+        case 9:
+        case 10:
+        case 11:
+            return "Autumn"
+        default:
+            return "invalid"
+    }
+}
+
+void main() {
+    for int d in 1..=7 {
+        println(day_name(d))
+    }
+
+    println(season(1))    # Winter
+    println(season(4))    # Spring
+    println(season(7))    # Summer
+    println(season(10))   # Autumn
+}

--- a/examples/03_control_flow/while_loop.dux
+++ b/examples/03_control_flow/while_loop.dux
@@ -1,0 +1,45 @@
+void main() {
+    # Basic while loop
+    int i = 0
+    while (i < 5) {
+        println(i)
+        i = i + 1
+    }
+
+    # Summing with while
+    int sum = 0
+    int n = 1
+    while (n <= 100) {
+        sum = sum + n
+        n = n + 1
+    }
+    println(sum)   # 5050
+
+    # Countdown
+    int count = 5
+    while (count > 0) {
+        println(count)
+        count = count - 1
+    }
+    println("liftoff!")
+
+    # Break out of a loop early
+    int x = 0
+    while (1) {
+        if (x >= 3) {
+            break
+        }
+        println(x)
+        x = x + 1
+    }
+
+    # Continue skips the rest of the body
+    int j = 0
+    while (j < 8) {
+        j = j + 1
+        if (j % 2 == 0) {
+            continue
+        }
+        println(j)   # prints only odd: 1 3 5 7
+    }
+}

--- a/examples/04_functions/basics.dux
+++ b/examples/04_functions/basics.dux
@@ -1,0 +1,55 @@
+# Functions must declare a return type.
+# void means no return value.
+
+void greet(str name) {
+    println("Hello, " + name + "!")
+}
+
+int add(int a, int b) {
+    return a + b
+}
+
+double average(double a, double b, double c) {
+    return (a + b + c) / 3.0
+}
+
+int absolute(int n) {
+    if (n < 0) {
+        return 0 - n
+    }
+    return n
+}
+
+int max2(int a, int b) {
+    if (a > b) {
+        return a
+    }
+    return b
+}
+
+str repeat(str s, int times) {
+    str result = ""
+    for int i in range(times) {
+        result = result + s
+    }
+    return result
+}
+
+void main() {
+    greet("World")               # Hello, World!
+    greet("Dux")                 # Hello, Dux!
+
+    println(add(3, 4))           # 7
+    println(add(-10, 10))        # 0
+
+    println(average(1.0, 2.0, 3.0))  # 2
+
+    println(absolute(-42))       # 42
+    println(absolute(7))         # 7
+
+    println(max2(10, 20))        # 20
+    println(max2(99, 3))         # 99
+
+    println(repeat("ab", 4))     # abababab
+    println(repeat("-", 20))     # --------------------
+}

--- a/examples/04_functions/higher_order.dux
+++ b/examples/04_functions/higher_order.dux
@@ -1,0 +1,59 @@
+# Functions that take other functions as arguments via function calls,
+# or that build results using helper functions.
+
+int apply_twice(int n) {
+    return n * 2
+}
+
+int apply_thrice(int n) {
+    return n * 3
+}
+
+int compose(int x, int times) {
+    int result = x
+    for int i in range(times) {
+        result = result * 2
+    }
+    return result
+}
+
+int sum_range(int lo, int hi) {
+    int total = 0
+    for int i in lo..=hi {
+        total = total + i
+    }
+    return total
+}
+
+int product_range(int lo, int hi) {
+    int total = 1
+    for int i in lo..=hi {
+        total = total * i
+    }
+    return total
+}
+
+str map_to_str(int val) {
+    if (val < 0) {
+        return "neg"
+    }
+    if (val == 0) {
+        return "zero"
+    }
+    return "pos"
+}
+
+void main() {
+    println(apply_twice(5))    # 10
+    println(apply_thrice(5))   # 15
+    println(compose(1, 8))     # 256  (1 * 2^8)
+
+    println(sum_range(1, 10))     # 55
+    println(product_range(1, 6))  # 720  (6!)
+
+    # Map concept — applying a transform to each value
+    for int i in -2..=2 {
+        println(map_to_str(i))
+    }
+    # neg, neg, zero, pos, pos
+}

--- a/examples/04_functions/recursion.dux
+++ b/examples/04_functions/recursion.dux
@@ -1,0 +1,54 @@
+int factorial(int n) {
+    if (n <= 1) {
+        return 1
+    }
+    return n * factorial(n - 1)
+}
+
+int fibonacci(int n) {
+    if (n <= 0) {
+        return 0
+    }
+    if (n == 1) {
+        return 1
+    }
+    return fibonacci(n - 1) + fibonacci(n - 2)
+}
+
+int gcd(int a, int b) {
+    if (b == 0) {
+        return a
+    }
+    return gcd(b, a % b)
+}
+
+int power(int base, int exp) {
+    if (exp == 0) {
+        return 1
+    }
+    if (exp % 2 == 0) {
+        int half = power(base, exp / 2)
+        return half * half
+    }
+    return base * power(base, exp - 1)
+}
+
+void main() {
+    # Factorials
+    for int i in 0..=10 {
+        println(factorial(i))
+    }
+
+    # Fibonacci sequence
+    for int i in 0..=10 {
+        println(fibonacci(i))
+    }
+
+    # GCD
+    println(gcd(48, 18))   # 6
+    println(gcd(100, 75))  # 25
+
+    # Fast exponentiation
+    println(power(2, 10))  # 1024
+    println(power(3, 5))   # 243
+}

--- a/examples/05_collections/dicts.dux
+++ b/examples/05_collections/dicts.dux
@@ -1,0 +1,26 @@
+void main() {
+    # Create a dict and insert key-value pairs
+    dict scores
+    scores = {}
+    scores["alice"] = 95
+    scores["bob"]   = 82
+    scores["carol"] = 91
+
+    # Lookup
+    println(scores["alice"])   # 95
+    println(scores["bob"])     # 82
+
+    # Update a value
+    scores["bob"] = 88
+    println(scores["bob"])     # 88
+
+    # String keys and string values
+    dict capitals
+    capitals = {}
+    capitals["France"]  = "Paris"
+    capitals["Germany"] = "Berlin"
+    capitals["Japan"]   = "Tokyo"
+
+    println(capitals["France"])    # Paris
+    println(capitals["Japan"])     # Tokyo
+}

--- a/examples/05_collections/lists.dux
+++ b/examples/05_collections/lists.dux
@@ -1,0 +1,25 @@
+void main() {
+    # Create a list and push elements
+    list nums
+    nums = []
+    nums[len(nums)] = 10
+    nums[len(nums)] = 20
+    nums[len(nums)] = 30
+
+    # Access by index
+    println(nums[0])   # 10
+    println(nums[1])   # 20
+    println(nums[2])   # 30
+    println(len(nums)) # 3
+
+    # Iterate with for-range
+    for int i in range(len(nums)) {
+        println(nums[i])
+    }
+
+    # Nested list — list of lists
+    list row0
+    list row1
+    row0 = []
+    row1 = []
+}

--- a/examples/06_classes/basics.dux
+++ b/examples/06_classes/basics.dux
@@ -1,0 +1,105 @@
+str int_to_str(int n) {
+    if (n == 0) {
+        return "0"
+    }
+    str result = ""
+    int neg = 0
+    if (n < 0) {
+        neg = 1
+        n = 0 - n
+    }
+    while (n > 0) {
+        int digit = n % 10
+        if (digit == 0) {
+            result = "0" + result
+        } else if (digit == 1) {
+            result = "1" + result
+        } else if (digit == 2) {
+            result = "2" + result
+        } else if (digit == 3) {
+            result = "3" + result
+        } else if (digit == 4) {
+            result = "4" + result
+        } else if (digit == 5) {
+            result = "5" + result
+        } else if (digit == 6) {
+            result = "6" + result
+        } else if (digit == 7) {
+            result = "7" + result
+        } else if (digit == 8) {
+            result = "8" + result
+        } else {
+            result = "9" + result
+        }
+        n = n / 10
+    }
+    if (neg == 1) {
+        result = "-" + result
+    }
+    return result
+}
+
+class Rectangle {
+    int width
+    int height
+
+    Rectangle(int w, int h) {
+        this.width  = w
+        this.height = h
+    }
+
+    int area() {
+        return this.width * this.height
+    }
+
+    int perimeter() {
+        return 2 * (this.width + this.height)
+    }
+
+    str describe() {
+        return "Rectangle " + int_to_str(this.width) + "x" + int_to_str(this.height)
+    }
+}
+
+class Counter {
+    int value
+
+    Counter(int start) {
+        this.value = start
+    }
+
+    void increment() {
+        this.value = this.value + 1
+    }
+
+    void decrement() {
+        this.value = this.value - 1
+    }
+
+    void add(int n) {
+        this.value = this.value + n
+    }
+
+    int getValue() {
+        return this.value
+    }
+}
+
+void main() {
+    Rectangle r = new Rectangle(5, 3)
+    println(r.area())        # 15
+    println(r.perimeter())   # 16
+    println(r.describe())    # Rectangle 5x3
+    delete r
+
+    Counter c = new Counter(0)
+    c.increment()
+    c.increment()
+    c.increment()
+    println(c.getValue())   # 3
+    c.add(10)
+    println(c.getValue())   # 13
+    c.decrement()
+    println(c.getValue())   # 12
+    delete c
+}

--- a/examples/06_classes/inheritance.dux
+++ b/examples/06_classes/inheritance.dux
@@ -1,0 +1,111 @@
+class Shape {
+    str color
+
+    Shape(str color) {
+        this.color = color
+    }
+
+    str getColor() {
+        return this.color
+    }
+
+    str kind() {
+        return "shape"
+    }
+
+    str describe() {
+        return this.kind() + " [" + this.color + "]"
+    }
+}
+
+class Circle(Shape) {
+    int radius
+
+    Circle(str color, int radius) {
+        this.color  = color
+        this.radius = radius
+    }
+
+    str kind() {
+        return "circle"
+    }
+
+    int radius_val() {
+        return this.radius
+    }
+}
+
+class Square(Shape) {
+    int side
+
+    Square(str color, int side) {
+        this.color = color
+        this.side  = side
+    }
+
+    str kind() {
+        return "square"
+    }
+
+    int area() {
+        return this.side * this.side
+    }
+}
+
+class Animal {
+    str name
+
+    Animal(str n) {
+        this.name = n
+    }
+
+    str getName() {
+        return this.name
+    }
+
+    str sound() {
+        return "..."
+    }
+}
+
+class Dog(Animal) {
+    Dog(str n) {
+        this.name = n
+    }
+
+    str sound() {
+        return "Woof"
+    }
+}
+
+class Cat(Animal) {
+    Cat(str n) {
+        this.name = n
+    }
+
+    str sound() {
+        return "Meow"
+    }
+}
+
+void main() {
+    Circle c = new Circle("red", 5)
+    println(c.getColor())    # red
+    println(c.kind())        # circle
+    println(c.describe())    # circle [red]
+    delete c
+
+    Square s = new Square("blue", 4)
+    println(s.getColor())    # blue
+    println(s.area())        # 16
+    println(s.describe())    # square [blue]
+    delete s
+
+    Dog dog = new Dog("Rex")
+    println(dog.sound())     # Woof
+    delete dog
+
+    Cat cat = new Cat("Whiskers")
+    println(cat.sound())     # Meow
+    delete cat
+}

--- a/examples/07_math/stdlib.dux
+++ b/examples/07_math/stdlib.dux
@@ -1,0 +1,59 @@
+import math
+
+void main() {
+    # Square root
+    println(math.sqrt(16.0))    # 4
+    println(math.sqrt(2.0))     # 1.41421...
+
+    # Power
+    println(math.pow(2.0, 10.0))  # 1024
+    println(math.pow(3.0, 3.0))   # 27
+
+    # Rounding
+    println(math.floor(3.9))   # 3
+    println(math.ceil(3.1))    # 4
+    println(math.floor(-2.3))  # -3
+    println(math.ceil(-2.7))   # -2
+
+    # Absolute value
+    println(math.abs(-5.5))    # 5.5
+    println(math.abs(3.2))     # 3.2
+
+    # Min and max
+    println(math.min(3.0, 7.0))   # 3
+    println(math.max(3.0, 7.0))   # 7
+
+    # Logarithms
+    println(math.log(2.71828))    # ~1 (natural log)
+    println(math.log2(8.0))       # 3
+
+    # Trigonometry (radians)
+    println(math.sin(0.0))    # 0
+    println(math.cos(0.0))    # 1
+
+    # Combining math operations
+    # Hypotenuse of a 3-4-5 triangle
+    double hyp = math.sqrt(math.pow(3.0, 2.0) + math.pow(4.0, 2.0))
+    println(hyp)   # 5
+
+    # Compound interest: A = P * (1 + r)^n
+    double principal = 1000.0
+    double rate      = 0.05
+    double years     = 10.0
+    double amount    = principal * math.pow(1.0 + rate, years)
+    println(amount)   # ~1628.89
+
+    # Approximating pi via Leibniz series
+    double pi = 0.0
+    int terms = 10000
+    for int i in range(terms) {
+        double t = 1.0 / (2.0 * i + 1.0)
+        if (i % 2 == 0) {
+            pi = pi + t
+        } else {
+            pi = pi - t
+        }
+    }
+    pi = pi * 4.0
+    println(pi)   # ~3.14159...
+}

--- a/examples/08_error_handling/exceptions.dux
+++ b/examples/08_error_handling/exceptions.dux
@@ -1,0 +1,100 @@
+str int_to_str(int n) {
+    if (n == 0) {
+        return "0"
+    }
+    str result = ""
+    int neg = 0
+    if (n < 0) {
+        neg = 1
+        n = 0 - n
+    }
+    while (n > 0) {
+        int digit = n % 10
+        if (digit == 0) {
+            result = "0" + result
+        } else if (digit == 1) {
+            result = "1" + result
+        } else if (digit == 2) {
+            result = "2" + result
+        } else if (digit == 3) {
+            result = "3" + result
+        } else if (digit == 4) {
+            result = "4" + result
+        } else if (digit == 5) {
+            result = "5" + result
+        } else if (digit == 6) {
+            result = "6" + result
+        } else if (digit == 7) {
+            result = "7" + result
+        } else if (digit == 8) {
+            result = "8" + result
+        } else {
+            result = "9" + result
+        }
+        n = n / 10
+    }
+    if (neg == 1) {
+        result = "-" + result
+    }
+    return result
+}
+
+# Error handling via return codes — return -1 for error, >= 0 for success.
+
+int safe_divide(int a, int b) {
+    if (b == 0) {
+        return -1
+    }
+    return a / b
+}
+
+int sqrt_int(int n) {
+    if (n < 0) {
+        return -1
+    }
+    int i = 0
+    while (i * i <= n) {
+        i = i + 1
+    }
+    return i - 1
+}
+
+# try/catch blocks catch runtime exceptions from the runtime.
+void demo_try_catch() {
+    try {
+        println("inside try block")
+        println("no exception raised here")
+    } catch ... {
+        println("caught a runtime exception")
+    }
+    println("execution continues after try/catch")
+}
+
+void main() {
+    # Division with error check
+    int result = safe_divide(10, 2)
+    if (result >= 0) {
+        println("10 / 2 = " + int_to_str(result))
+    }
+
+    int err = safe_divide(10, 0)
+    if (err < 0) {
+        println("error: division by zero")
+    }
+
+    # Square root with range check
+    int r1 = sqrt_int(25)
+    if (r1 >= 0) {
+        println("sqrt(25) = " + int_to_str(r1))
+    }
+
+    int r2 = sqrt_int(-4)
+    if (r2 < 0) {
+        println("error: sqrt of negative number")
+    }
+
+    # try/catch for runtime exceptions
+    demo_try_catch()
+
+    println("program completed normally")
+}

--- a/examples/09_imports/README.md
+++ b/examples/09_imports/README.md
@@ -1,0 +1,40 @@
+# Imports in Dux
+
+## Standard Library Modules
+
+Dux ships with three built-in modules:
+
+| Module | Functions |
+|--------|-----------|
+| `math` | `sqrt`, `pow`, `floor`, `ceil`, `abs`, `log`, `log2`, `sin`, `cos`, `min`, `max` |
+| `str`  | `concat`, `from_int`, `from_double`, `length`, `slice` |
+| `io`   | `println`, `print`, `readline` |
+
+Import a module at the top of your file:
+
+```dux
+import math
+import str
+import io
+```
+
+Then call functions with dot notation:
+
+```dux
+double x = math.sqrt(9.0)    # 3.0
+str s    = str.from_int(42)  # "42"
+io.println("hello")
+```
+
+## User-File Imports
+
+The import syntax supports dotted paths for file-based modules:
+
+```dux
+import utils
+import geometry.shapes
+import myapp.models.user
+```
+
+This feature is on the roadmap — the syntax is parsed and validated today,
+and the multi-file compilation pass will resolve these paths at link time.

--- a/examples/09_imports/using_stdlib.dux
+++ b/examples/09_imports/using_stdlib.dux
@@ -1,0 +1,37 @@
+import math
+import io
+
+# Dux provides standard-library modules importable with `import`.
+# Modules expose their functions via dot-notation: module.function(args).
+#
+# Available modules:
+#   math  — sqrt, pow, floor, ceil, abs, log, log2, sin, cos, min, max
+#   io    — println, print, readline
+
+void main() {
+    # ── math module ───────────────────────────────────────────────────────────
+    double root = math.sqrt(144.0)
+    io.println("sqrt(144) = ")
+    println(root)                     # 12
+
+    double result = math.pow(2.0, 8.0)
+    println(result)                   # 256
+
+    println(math.floor(3.9))          # 3
+    println(math.ceil(3.1))           # 4
+    println(math.abs(-7.5))           # 7.5
+    println(math.min(4.0, 9.0))       # 4
+    println(math.max(4.0, 9.0))       # 9
+    println(math.log2(16.0))          # 4
+    println(math.sin(0.0))            # 0
+    println(math.cos(0.0))            # 1
+
+    # ── io module ─────────────────────────────────────────────────────────────
+    io.println("Printed via io.println")
+    io.print("no newline: ")
+    io.println("followed by io.println")
+
+    # io.readline reads a line from stdin (uncomment to use interactively)
+    # str line = io.readline()
+    # io.println("you typed: " + line)
+}

--- a/examples/10_algorithms/collatz.dux
+++ b/examples/10_algorithms/collatz.dux
@@ -1,0 +1,101 @@
+str int_to_str(int n) {
+    if (n == 0) {
+        return "0"
+    }
+    str result = ""
+    int neg = 0
+    if (n < 0) {
+        neg = 1
+        n = 0 - n
+    }
+    while (n > 0) {
+        int digit = n % 10
+        if (digit == 0) {
+            result = "0" + result
+        } else if (digit == 1) {
+            result = "1" + result
+        } else if (digit == 2) {
+            result = "2" + result
+        } else if (digit == 3) {
+            result = "3" + result
+        } else if (digit == 4) {
+            result = "4" + result
+        } else if (digit == 5) {
+            result = "5" + result
+        } else if (digit == 6) {
+            result = "6" + result
+        } else if (digit == 7) {
+            result = "7" + result
+        } else if (digit == 8) {
+            result = "8" + result
+        } else {
+            result = "9" + result
+        }
+        n = n / 10
+    }
+    if (neg == 1) {
+        result = "-" + result
+    }
+    return result
+}
+
+# Collatz conjecture: starting from any positive integer n,
+# repeatedly apply: n = n/2 if even, n = 3n+1 if odd.
+# The sequence always reaches 1 (unproven in general, true for all tested n).
+
+int collatz_length(int n) {
+    int steps = 0
+    while (n != 1) {
+        if (n % 2 == 0) {
+            n = n / 2
+        } else {
+            n = 3 * n + 1
+        }
+        steps = steps + 1
+    }
+    return steps
+}
+
+void print_collatz(int n) {
+    print(int_to_str(n))
+    while (n != 1) {
+        if (n % 2 == 0) {
+            n = n / 2
+        } else {
+            n = 3 * n + 1
+        }
+        print(" -> " + int_to_str(n))
+    }
+    println("")
+}
+
+int longest_collatz_under(int limit) {
+    int best_start = 1
+    int best_len   = 0
+    int n = 1
+    while (n < limit) {
+        int cl = collatz_length(n)
+        if (cl > best_len) {
+            best_len   = cl
+            best_start = n
+        }
+        n = n + 1
+    }
+    return best_start
+}
+
+void main() {
+    # Print the sequence for a few starting values
+    print_collatz(6)    # 6 -> 3 -> 10 -> 5 -> 16 -> 8 -> 4 -> 2 -> 1
+    print_collatz(27)   # long sequence
+
+    # Lengths for 1..20
+    for int i in 1..=20 {
+        println(collatz_length(i))
+    }
+
+    # Which n < 1000 has the longest Collatz sequence?
+    int best = longest_collatz_under(1000)
+    println(best)            # 871  (sequence length 178)
+    println(collatz_length(best))
+}

--- a/examples/10_algorithms/fibonacci.dux
+++ b/examples/10_algorithms/fibonacci.dux
@@ -1,0 +1,55 @@
+# Two implementations of Fibonacci — recursive and iterative.
+# The iterative version handles large n without stack overflow.
+
+int fib_recursive(int n) {
+    if (n <= 0) {
+        return 0
+    }
+    if (n == 1) {
+        return 1
+    }
+    return fib_recursive(n - 1) + fib_recursive(n - 2)
+}
+
+int fib_iterative(int n) {
+    if (n <= 0) {
+        return 0
+    }
+    if (n == 1) {
+        return 1
+    }
+    int a = 0
+    int b = 1
+    int i = 2
+    while (i <= n) {
+        int next = a + b
+        a = b
+        b = next
+        i = i + 1
+    }
+    return b
+}
+
+void main() {
+    # First 15 terms (recursive — fine for small n)
+    println("Recursive:")
+    for int i in 0..=14 {
+        println(fib_recursive(i))
+    }
+
+    # First 40 terms (iterative — efficient)
+    println("Iterative:")
+    for int i in 0..=39 {
+        println(fib_iterative(i))
+    }
+
+    # Verify both agree for n=0..15
+    for int i in 0..=15 {
+        int r = fib_recursive(i)
+        int it = fib_iterative(i)
+        if (r != it) {
+            println("MISMATCH")
+        }
+    }
+    println("both agree for n=0..15")
+}

--- a/examples/10_algorithms/primes.dux
+++ b/examples/10_algorithms/primes.dux
@@ -1,0 +1,119 @@
+str int_to_str(int n) {
+    if (n == 0) {
+        return "0"
+    }
+    str result = ""
+    int neg = 0
+    if (n < 0) {
+        neg = 1
+        n = 0 - n
+    }
+    while (n > 0) {
+        int digit = n % 10
+        if (digit == 0) {
+            result = "0" + result
+        } else if (digit == 1) {
+            result = "1" + result
+        } else if (digit == 2) {
+            result = "2" + result
+        } else if (digit == 3) {
+            result = "3" + result
+        } else if (digit == 4) {
+            result = "4" + result
+        } else if (digit == 5) {
+            result = "5" + result
+        } else if (digit == 6) {
+            result = "6" + result
+        } else if (digit == 7) {
+            result = "7" + result
+        } else if (digit == 8) {
+            result = "8" + result
+        } else {
+            result = "9" + result
+        }
+        n = n / 10
+    }
+    if (neg == 1) {
+        result = "-" + result
+    }
+    return result
+}
+
+int count_divisors(int n) {
+    int count = 0
+    int i = 1
+    while (i * i <= n) {
+        if (n % i == 0) {
+            count = count + 2
+            if (i * i == n) {
+                count = count - 1
+            }
+        }
+        i = i + 1
+    }
+    return count
+}
+
+int is_prime(int n) {
+    if (n < 2) {
+        return 0
+    }
+    if (n == 2) {
+        return 1
+    }
+    if (n % 2 == 0) {
+        return 0
+    }
+    int i = 3
+    while (i * i <= n) {
+        if (n % i == 0) {
+            return 0
+        }
+        i = i + 2
+    }
+    return 1
+}
+
+void print_primes_up_to(int limit) {
+    int n = 2
+    while (n <= limit) {
+        if (is_prime(n)) {
+            print(int_to_str(n) + " ")
+        }
+        n = n + 1
+    }
+    println("")
+}
+
+int nth_prime(int n) {
+    int count = 0
+    int candidate = 1
+    while (count < n) {
+        candidate = candidate + 1
+        if (is_prime(candidate)) {
+            count = count + 1
+        }
+    }
+    return candidate
+}
+
+void main() {
+    # All primes up to 50
+    print_primes_up_to(50)
+    # 2 3 5 7 11 13 17 19 23 29 31 37 41 43 47
+
+    # Count primes up to 100
+    int prime_count = 0
+    for int i in 2..=100 {
+        if (is_prime(i)) {
+            prime_count = prime_count + 1
+        }
+    }
+    println(prime_count)   # 25
+
+    # First 10 primes
+    for int i in 1..=10 {
+        println(nth_prime(i))
+    }
+    # 2 3 5 7 11 13 17 19 23 29
+}

--- a/examples/10_algorithms/sorting.dux
+++ b/examples/10_algorithms/sorting.dux
@@ -1,0 +1,111 @@
+str int_to_str(int n) {
+    if (n == 0) {
+        return "0"
+    }
+    str result = ""
+    int neg = 0
+    if (n < 0) {
+        neg = 1
+        n = 0 - n
+    }
+    while (n > 0) {
+        int digit = n % 10
+        if (digit == 0) {
+            result = "0" + result
+        } else if (digit == 1) {
+            result = "1" + result
+        } else if (digit == 2) {
+            result = "2" + result
+        } else if (digit == 3) {
+            result = "3" + result
+        } else if (digit == 4) {
+            result = "4" + result
+        } else if (digit == 5) {
+            result = "5" + result
+        } else if (digit == 6) {
+            result = "6" + result
+        } else if (digit == 7) {
+            result = "7" + result
+        } else if (digit == 8) {
+            result = "8" + result
+        } else {
+            result = "9" + result
+        }
+        n = n / 10
+    }
+    if (neg == 1) {
+        result = "-" + result
+    }
+    return result
+}
+
+import math
+
+# Bubble sort — sort a fixed-size sequence represented as a function
+# that returns the i-th element (Dux lists are being used for small arrays).
+
+int bubble_sort_steps(int n) {
+    # Count swaps needed to sort [n, n-1, ..., 1] (reverse order)
+    int swaps = 0
+    int size = n
+    int pass = 0
+    while (pass < size - 1) {
+        int i = 0
+        while (i < size - 1 - pass) {
+            # Would compare arr[i] and arr[i+1]; count swap if needed
+            # Here we simulate on a numeric sequence
+            swaps = swaps + 1
+            i = i + 1
+        }
+        pass = pass + 1
+    }
+    return swaps
+}
+
+# Binary search on a virtual sorted sequence 0, 1, ..., n-1
+int binary_search(int target, int size) {
+    int lo = 0
+    int hi = size - 1
+    int steps = 0
+    while (lo <= hi) {
+        int mid = (lo + hi) / 2
+        steps = steps + 1
+        if (mid == target) {
+            return steps
+        } else if (mid < target) {
+            lo = mid + 1
+        } else {
+            hi = mid - 1
+        }
+    }
+    return -1
+}
+
+# Merge count — number of comparisons in merge of two sorted halves of size n
+int merge_comparisons(int n) {
+    # Upper bound: two halves of n/2 merged = at most n comparisons
+    return n
+}
+
+void main() {
+    # Binary search: how many steps to find target in sorted array of size?
+    println(binary_search(0, 16))    # 1st element needs ~4 steps
+    println(binary_search(15, 16))   # last element ~4 steps
+    println(binary_search(7, 16))    # middle ~1 step
+
+    # Verify O(log n) growth
+    for int exp in 1..=10 {
+        int size = 1
+        for int i in range(exp) {
+            size = size * 2
+        }
+        int steps = binary_search(0, size)
+        println(int_to_str(size) + " elements: " + int_to_str(steps) + " steps")
+    }
+
+    # Bubble sort comparisons for n elements
+    for int n in 2..=8 {
+        int s = bubble_sort_steps(n)
+        println("n=" + int_to_str(n) + " comparisons=" + int_to_str(s))
+    }
+}

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -1298,9 +1298,12 @@ Value* Codegen::gen_binary(const ast::BinaryExpr& e) {
     TypeId lt = type_id_of(*e.left);
     TypeId rt = type_id_of(*e.right);
 
-    // Promote types
+    // Promote types — also fall back to checking the actual LLVM types for
+    // cases where type_id is TID_UNKNOWN (e.g. stdlib member calls like math.sqrt).
     bool is_fp = (lt == TR::TID_DOUBLE || lt == TR::TID_REAL ||
-                  rt == TR::TID_DOUBLE || rt == TR::TID_REAL);
+                  rt == TR::TID_DOUBLE || rt == TR::TID_REAL ||
+                  L->getType()->isFloatingPointTy() ||
+                  R->getType()->isFloatingPointTy());
     if (is_fp) {
         if (L->getType()->isIntegerTy())
             L = builder_->CreateSIToFP(L, llvm::Type::getDoubleTy(*ctx_));


### PR DESCRIPTION
When both operands of a binary expression have type_id TID_UNKNOWN (e.g. stdlib member calls like math.sqrt/math.pow whose return types are not tracked through the sema member-call path), the is_fp flag was false even though the LLVM values were doubles. This caused LLVM IR verification failures ("Integer arithmetic operators only work with integral types") when combining two stdlib math results with +, -, etc.

Fix: also check L->getType()->isFloatingPointTy() and R->getType()->isFloatingPointTy() as a fallback so the correct fadd/ fsub/fmul/fdiv instructions are emitted.

examples: add 24 feature-showcase examples across 10 folders covering basics, strings, control flow, functions, collections, classes, math, error handling, imports and classic algorithms. All examples compile and produce correct output.