### PR TITLE
fix: eliminate all grammar warnings, switch fallthrough, and dead code

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -17,7 +17,6 @@ void CallExpr::accept(Visitor& v)      const { v.visit(*this); }
 void MemberExpr::accept(Visitor& v)    const { v.visit(*this); }
 void IndexExpr::accept(Visitor& v)     const { v.visit(*this); }
 void NewExpr::accept(Visitor& v)       const { v.visit(*this); }
-void FormatExpr::accept(Visitor& v)    const { v.visit(*this); }
 void ListExpr::accept(Visitor& v)      const { v.visit(*this); }
 void DictExpr::accept(Visitor& v)      const { v.visit(*this); }
 

--- a/src/ast/ast.hpp
+++ b/src/ast/ast.hpp
@@ -120,11 +120,6 @@ struct NewExpr final : Expr {
     void accept(Visitor& v) const override;
 };
 
-struct FormatExpr final : Expr {
-    ExprPtr tmpl;
-    ExprPtr args;   // ListExpr or DictExpr
-    void accept(Visitor& v) const override;
-};
 
 struct ListExpr final : Expr {
     ExprList elements;
@@ -360,7 +355,6 @@ struct Visitor {
     virtual void visit(const MemberExpr&)    = 0;
     virtual void visit(const IndexExpr&)     = 0;
     virtual void visit(const NewExpr&)       = 0;
-    virtual void visit(const FormatExpr&)    = 0;
     virtual void visit(const ListExpr&)      = 0;
     virtual void visit(const DictExpr&)      = 0;
 

--- a/src/ast/printer.hpp
+++ b/src/ast/printer.hpp
@@ -84,12 +84,6 @@ private:
         out_ << ')';
     }
 
-    void visit(const FormatExpr& n) override {
-        n.tmpl->accept(*this);
-        out_ << " % ";
-        n.args->accept(*this);
-    }
-
     void visit(const ListExpr& n) override {
         out_ << '[';
         for (std::size_t i = 0; i < n.elements.size(); ++i) {

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -713,6 +713,8 @@ void Codegen::gen_stmt(const ast::Stmt& s) {
         if (br->label) {
             for (auto it = loop_stack_.rbegin(); it != loop_stack_.rend(); ++it)
                 if (it->label == *br->label) { builder_->CreateBr(it->exit); return; }
+            err(br->loc, "label '" + *br->label + "' not found for break");
+            return;
         }
         builder_->CreateBr(loop_stack_.back().exit);
         return;
@@ -722,6 +724,8 @@ void Codegen::gen_stmt(const ast::Stmt& s) {
         if (co->label) {
             for (auto it = loop_stack_.rbegin(); it != loop_stack_.rend(); ++it)
                 if (it->label == *co->label) { builder_->CreateBr(it->header); return; }
+            err(co->loc, "label '" + *co->label + "' not found for continue");
+            return;
         }
         builder_->CreateBr(loop_stack_.back().header);
         return;
@@ -1015,9 +1019,22 @@ void Codegen::gen_for_c(const ast::ForCStmt& s) {
 
 void Codegen::gen_switch(const ast::SwitchStmt& s) {
     Function* fn  = builder_->GetInsertBlock()->getParent();
-    Value* sw_val = gen_expr(*s.expr);
     auto* exit_bb = BasicBlock::Create(*ctx_, "sw.end", fn);
 
+    // Evaluate case constant values before creating the switch (constants don't
+    // emit instructions, but keep this order to avoid inserting after a terminator)
+    std::vector<llvm::ConstantInt*> case_consts;
+    case_consts.reserve(s.cases.size());
+    for (const auto& c : s.cases) {
+        if (c.value) {
+            Value* cv = gen_expr(**c.value);
+            case_consts.push_back(llvm::dyn_cast<llvm::ConstantInt>(cv));
+        } else {
+            case_consts.push_back(nullptr);
+        }
+    }
+
+    Value* sw_val = gen_expr(*s.expr);
     // Ensure integer type for switch
     if (!sw_val->getType()->isIntegerTy())
         sw_val = builder_->CreateFPToSI(sw_val, llvm::Type::getInt64Ty(*ctx_));
@@ -1025,26 +1042,34 @@ void Codegen::gen_switch(const ast::SwitchStmt& s) {
     auto* sw_inst = builder_->CreateSwitch(sw_val, exit_bb,
                                            static_cast<unsigned>(s.cases.size()));
 
-    loop_stack_.push_back({nullptr, exit_bb, {}}); // break goes to exit
-
-    for (const auto& c : s.cases) {
+    // Create all case entry blocks and register them with the switch instruction
+    std::vector<BasicBlock*> case_bbs;
+    case_bbs.reserve(s.cases.size());
+    for (std::size_t i = 0; i < s.cases.size(); ++i) {
         BasicBlock* case_bb;
-        if (c.value) {
+        if (s.cases[i].value) {
             case_bb = BasicBlock::Create(*ctx_, "sw.case", fn);
-            Value* case_val = gen_expr(**c.value);
-            if (auto* ci = llvm::dyn_cast<llvm::ConstantInt>(case_val))
-                sw_inst->addCase(ci, case_bb);
+            if (case_consts[i])
+                sw_inst->addCase(case_consts[i], case_bb);
         } else {
             case_bb = BasicBlock::Create(*ctx_, "sw.default", fn);
             sw_inst->setDefaultDest(case_bb);
         }
+        case_bbs.push_back(case_bb);
+    }
 
-        builder_->SetInsertPoint(case_bb);
+    loop_stack_.push_back({nullptr, exit_bb, {}}); // break goes to exit
+
+    // Generate case bodies; unterminated cases fall through to the next case
+    for (std::size_t i = 0; i < s.cases.size(); ++i) {
+        builder_->SetInsertPoint(case_bbs[i]);
         env_push();
-        gen_stmts(c.body);
+        gen_stmts(s.cases[i].body);
         env_pop();
-        if (!builder_->GetInsertBlock()->getTerminator())
-            builder_->CreateBr(exit_bb);
+        if (!builder_->GetInsertBlock()->getTerminator()) {
+            BasicBlock* next_bb = (i + 1 < case_bbs.size()) ? case_bbs[i + 1] : exit_bb;
+            builder_->CreateBr(next_bb);
+        }
     }
 
     loop_stack_.pop_back();

--- a/src/parser/dux.y
+++ b/src/parser/dux.y
@@ -333,18 +333,18 @@ class_decl
     ;
 
 opt_base_list
-    : %empty
-    | LPAREN base_list RPAREN         { $$ = std::move($2); }
+    : %empty                             { $$ = std::vector<BaseClass>(); }
+    | LPAREN base_list RPAREN            { $$ = std::move($2); }
     ;
 
 class_body_or_semi
-    : SEMI
-    | LBRACE class_body RBRACE        { $$ = std::move($2); }
+    : SEMI                               { $$ = std::vector<ClassMember>(); }
+    | LBRACE class_body RBRACE           { $$ = std::move($2); }
     ;
 
 base_list
-    : %empty
-    | base_list_ne                    { $$ = std::move($1); }
+    : %empty                             { $$ = std::vector<BaseClass>(); }
+    | base_list_ne                       { $$ = std::move($1); }
     ;
 
 base_list_ne
@@ -366,7 +366,7 @@ class_ref
     ;
 
 class_body
-    : %empty
+    : %empty          { $$ = std::vector<ClassMember>(); }
     | class_members   { $$ = std::move($1); }
     ;
 
@@ -424,7 +424,7 @@ interface_decl
     ;
 
 interface_members
-    : %empty
+    : %empty                              { $$ = std::vector<ClassMember>(); }
     | interface_members SEMI              { $$ = std::move($1); }
     | interface_members interface_member
         { $1.push_back(std::move($2)); $$ = std::move($1); }
@@ -492,7 +492,7 @@ ctor_decl
     ;
 
 opt_init_list
-    : %empty
+    : %empty          { $$ = std::vector<InitEntry>(); }
     | COLON init_list { $$ = std::move($2); }
     ;
 
@@ -544,7 +544,7 @@ field_decl
    ===================================================================== */
 
 decorators
-    : %empty
+    : %empty                { $$ = std::vector<Decorator>(); }
     | decorators decorator  { $1.push_back(std::move($2)); $$ = std::move($1); }
     ;
 
@@ -571,7 +571,7 @@ decorator_name
    ===================================================================== */
 
 param_list
-    : %empty
+    : %empty          { $$ = std::vector<Param>(); }
     | param_list_ne   { $$ = std::move($1); }
     ;
 
@@ -737,7 +737,7 @@ switch_stmt
     ;
 
 switch_cases
-    : %empty
+    : %empty                          { $$ = std::vector<SwitchCase>(); }
     | switch_cases switch_case        { $1.push_back(std::move($2)); $$ = std::move($1); }
     ;
 
@@ -784,6 +784,8 @@ break_stmt
 continue_stmt
     : KW_CONTINUE SEMI
         { auto s = mk<ContinueStmt>(); s->loc = sl(@$, driver); $$ = std::move(s); }
+    | KW_CONTINUE AMP IDENT SEMI
+        { auto s = mk<ContinueStmt>(); s->loc = sl(@$, driver); s->label = $3; $$ = std::move(s); }
     ;
 
 /* -- Assert ------------------------------------------------------------ */
@@ -955,7 +957,7 @@ dict_lit
     ;
 
 dict_pairs
-    : %empty
+    : %empty                              { $$ = PairList(); }
     | expr COLON expr                     { $$.emplace_back(std::move($1), std::move($3)); }
     | dict_pairs COMMA expr COLON expr    { $1.emplace_back(std::move($3), std::move($5)); $$ = std::move($1); }
     | dict_pairs COMMA                    { $$ = std::move($1); }

--- a/src/sema/sema.cpp
+++ b/src/sema/sema.cpp
@@ -591,8 +591,6 @@ TypeId Sema::check_expr(const ast::Expr& e) {
         result = check_list(*lst_e);
     } else if (auto* dct_e  = dynamic_cast<const ast::DictExpr*>(&e)) {
         result = check_dict(*dct_e);
-    } else if (dynamic_cast<const ast::FormatExpr*>(&e)) {
-        result = TR::TID_STR;
     }
     // else: unknown Expr subtype — leave as TID_UNKNOWN
 


### PR DESCRIPTION
- Grammar: add explicit default actions to 10 empty rules on typed nonterminals (opt_base_list, class_body_or_semi, base_list, class_body, interface_members, opt_init_list, decorators, param_list, switch_cases, dict_pairs) — eliminates all Bison -Wother warnings
- Grammar: add labeled-continue rule to match labeled-break symmetry
- Codegen: fix switch fallthrough — previously empty cases always branched to exit; now each unterminated case falls through to the next case entry block (C-style semantics); this fixes the pre-existing season()-returns-null bug in examples/03_control_flow/switch.dux
- Codegen: fix labeled break/continue to emit an error when the named loop label is not found, instead of silently branching to the inner loop
- AST/Sema/Printer: remove FormatExpr — it was never produced by the parser, had no codegen handler, and was dead code throughout the compiler pipeline

Build: zero compiler warnings, zero Bison warnings, 90/90 tests pass