### PR TITLE
feat(defer): implement defer statement with LIFO scope-exit semantics

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -36,6 +36,7 @@ void ContinueStmt::accept(Visitor& v)  const { v.visit(*this); }
 void AssertStmt::accept(Visitor& v)    const { v.visit(*this); }
 void DeleteStmt::accept(Visitor& v)    const { v.visit(*this); }
 void LabeledStmt::accept(Visitor& v)   const { v.visit(*this); }
+void DeferStmt::accept(Visitor& v)     const { v.visit(*this); }
 
 void FunctionDecl::accept(Visitor& v)  const { v.visit(*this); }
 void FieldDecl::accept(Visitor& v)     const { v.visit(*this); }

--- a/src/ast/ast.hpp
+++ b/src/ast/ast.hpp
@@ -243,6 +243,11 @@ struct LabeledStmt final : Stmt {
     void accept(Visitor& v) const override;
 };
 
+struct DeferStmt final : Stmt {
+    StmtList body;
+    void accept(Visitor& v) const override;
+};
+
 // ─── Declarations ────────────────────────────────────────────────────────────
 
 struct Decl : Node {};
@@ -374,6 +379,7 @@ struct Visitor {
     virtual void visit(const AssertStmt&)    = 0;
     virtual void visit(const DeleteStmt&)    = 0;
     virtual void visit(const LabeledStmt&)   = 0;
+    virtual void visit(const DeferStmt&)     = 0;
 
     virtual void visit(const FunctionDecl&)  = 0;
     virtual void visit(const FieldDecl&)     = 0;

--- a/src/ast/printer.hpp
+++ b/src/ast/printer.hpp
@@ -241,6 +241,14 @@ private:
         n.stmt->accept(*this);
     }
 
+    void visit(const DeferStmt& n) override {
+        out_ << pad() << "defer {\n";
+        indent();
+        for (const auto& s : n.body) s->accept(*this);
+        dedent();
+        out_ << pad() << "}\n";
+    }
+
     // ── Declarations ─────────────────────────────────────────────────────────
     static const char* access_str(AccessMod m) {
         switch (m) {

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -390,7 +390,7 @@ void Codegen::gen_func(const ast::FunctionDecl& f, const std::string& mangled,
     // RAII cleanup (class dtors + str releases) must happen before the
     // return instruction, just as gen_return() does for explicit returns.
     if (!builder_->GetInsertBlock()->getTerminator()) {
-        emit_all_obj_dtors();
+        emit_all_scope_cleanups();
         emit_all_str_releases();
         if (current_ret_type_ == TR::TID_VOID)
             builder_->CreateRetVoid();
@@ -745,6 +745,7 @@ void Codegen::gen_stmt(const ast::Stmt& s) {
     }
     if (auto* a = dynamic_cast<const ast::AssertStmt*>(&s))    { gen_assert(*a);   return; }
     if (auto* d = dynamic_cast<const ast::DeleteStmt*>(&s))    { gen_delete(*d);   return; }
+    if (auto* df = dynamic_cast<const ast::DeferStmt*>(&s))    { gen_defer(*df);   return; }
     if (auto* ls = dynamic_cast<const ast::LabeledStmt*>(&s))  {
         // Propagate label into the inner loop/while statement
         pending_label_ = ls->label;
@@ -1153,9 +1154,8 @@ void Codegen::gen_return(const ast::ReturnStmt& s) {
         if (current_ret_type_ == TR::TID_STR)
             val = maybe_retain_str(val);
     }
-    // Destroy class instances and release str variables across all active scopes.
-    // Objects first (they may own str fields), then bare str locals.
-    emit_all_obj_dtors();
+    // Destroy class instances, run defers, and release str variables across all active scopes.
+    emit_all_scope_cleanups();
     emit_all_str_releases();
     if (val)
         builder_->CreateRet(val);
@@ -1902,22 +1902,21 @@ TypeId Codegen::type_id_of(const ast::Expr& e) const {
 void Codegen::env_push() {
     env_.emplace_back();
     str_scopes_.emplace_back();
-    obj_scopes_.emplace_back();
+    cleanup_scopes_.emplace_back();
 }
 
 void Codegen::env_pop() {
     auto* bb = builder_->GetInsertBlock();
     bool live = bb && !bb->getTerminator();
 
-    // Call dtors for class instances in LIFO order.
-    if (!obj_scopes_.empty()) {
+    // Run RAII dtors and defer blocks in LIFO order.
+    if (!cleanup_scopes_.empty()) {
         if (live) {
-            auto& scope = obj_scopes_.back();
+            auto& scope = cleanup_scopes_.back();
             for (int i = static_cast<int>(scope.size()) - 1; i >= 0; --i)
-                emit_dtor(scope[static_cast<std::size_t>(i)].alloca,
-                          scope[static_cast<std::size_t>(i)].class_name);
+                emit_scope_cleanup(scope[static_cast<std::size_t>(i)]);
         }
-        obj_scopes_.pop_back();
+        cleanup_scopes_.pop_back();
     }
 
     // Emit releases for str variables going out of scope.
@@ -1940,10 +1939,10 @@ void Codegen::env_define(const std::string& name, Value* alloca, TypeId tid) {
         return;
     }
     // Register class instances that have a destructor for automatic cleanup.
-    if (tid > TR::TID_NULL && !obj_scopes_.empty()) {
+    if (tid > TR::TID_NULL && !cleanup_scopes_.empty()) {
         const std::string& cls_name = types_.name_of(tid);
         if (!cls_name.empty() && mod_->getFunction(cls_name + "___dtor"))
-            obj_scopes_.back().push_back({alloca, cls_name});
+            cleanup_scopes_.back().push_back({alloca, cls_name, nullptr});
     }
 }
 
@@ -1975,15 +1974,29 @@ void Codegen::emit_dtor(Value* alloca, const std::string& class_name) {
     builder_->SetInsertPoint(end_bb);
 }
 
-void Codegen::emit_all_obj_dtors() {
+void Codegen::emit_scope_cleanup(const ScopeCleanup& c) {
     auto* bb = builder_->GetInsertBlock();
     if (!bb || bb->getTerminator()) return;
-    for (int i = static_cast<int>(obj_scopes_.size()) - 1; i >= 0; --i) {
-        auto& scope = obj_scopes_[static_cast<std::size_t>(i)];
+    if (c.defer_body)
+        gen_stmts(*c.defer_body);
+    else
+        emit_dtor(c.alloca, c.class_name);
+}
+
+void Codegen::emit_all_scope_cleanups() {
+    auto* bb = builder_->GetInsertBlock();
+    if (!bb || bb->getTerminator()) return;
+    for (int i = static_cast<int>(cleanup_scopes_.size()) - 1; i >= 0; --i) {
+        auto& scope = cleanup_scopes_[static_cast<std::size_t>(i)];
         for (int j = static_cast<int>(scope.size()) - 1; j >= 0; --j)
-            emit_dtor(scope[static_cast<std::size_t>(j)].alloca,
-                      scope[static_cast<std::size_t>(j)].class_name);
+            emit_scope_cleanup(scope[static_cast<std::size_t>(j)]);
     }
+}
+
+void Codegen::gen_defer(const ast::DeferStmt& s) {
+    if (cleanup_scopes_.empty()) return;
+    // Register the defer block; it will be emitted in LIFO order at scope exit.
+    cleanup_scopes_.back().push_back({nullptr, {}, &s.body});
 }
 
 Value* Codegen::make_alloca(llvm::Type* t, const std::string& name) {

--- a/src/codegen/codegen.hpp
+++ b/src/codegen/codegen.hpp
@@ -123,15 +123,21 @@ private:
     // so env_pop can emit duxrt_str_release calls for them.
     std::vector<std::vector<llvm::Value*>> str_scopes_;
 
-    // Scope-tracked class instances for automatic destructor calls (RAII).
-    // Populated by env_define() when the variable's type is a class that has
-    // a registered destructor.  env_pop() calls emit_dtor() on each in LIFO
-    // order; gen_return() calls emit_all_obj_dtors() across all open scopes.
-    struct ScopedObject {
-        llvm::Value* alloca;      // alloca holding the ptr to the heap object
-        std::string  class_name;  // used to resolve the destructor symbol
+    // Unified LIFO cleanup stack for both RAII and defer.
+    //
+    // Each entry is one of:
+    //   - Class RAII dtor:  alloca != nullptr, defer_body == nullptr
+    //   - Defer block:      alloca == nullptr, defer_body != nullptr
+    //
+    // Entries within a scope are processed in reverse-declaration order
+    // (LIFO) so that later declarations are destroyed first, matching
+    // C++ destructor ordering and Go's defer semantics.
+    struct ScopeCleanup {
+        llvm::Value*          alloca{nullptr};      // RAII: alloca holding heap ptr
+        std::string           class_name;            // RAII: destructor symbol prefix
+        const ast::StmtList*  defer_body{nullptr};  // defer: statements to run
     };
-    std::vector<std::vector<ScopedObject>> obj_scopes_;
+    std::vector<std::vector<ScopeCleanup>> cleanup_scopes_;
 
     // Cache of immortal DuxStr* globals for string literals (keyed by value).
     std::unordered_map<std::string, llvm::GlobalVariable*> str_lit_cache_;
@@ -216,6 +222,7 @@ private:
     void gen_var_decl(const ast::VarDeclStmt& s);
     void gen_assert(const ast::AssertStmt& s);
     void gen_delete(const ast::DeleteStmt& s);
+    void gen_defer(const ast::DeferStmt& s);
 
     // ── Expression codegen ───────────────────────────────────────────────
     llvm::Value* gen_expr(const ast::Expr& e);
@@ -246,11 +253,13 @@ private:
                       TypeId tid = TypeRegistry::TID_UNKNOWN);
     llvm::Value* env_lookup(const std::string& name) const;
 
-    // RAII destructor emission helpers
-    // Emits a null-guarded dtor call + free() for a single scoped class instance.
+    // Scope cleanup helpers (RAII + defer)
+    // Emit all cleanups across all active scopes in LIFO order (gen_return).
+    void emit_all_scope_cleanups();
+    // Emit one cleanup entry (RAII dtor or inline defer block).
+    void emit_scope_cleanup(const ScopeCleanup& c);
+    // Convenience: emit a null-guarded dtor + free for a class instance.
     void emit_dtor(llvm::Value* alloca, const std::string& class_name);
-    // Emits dtors for all obj_scopes_ in LIFO order (used by gen_return).
-    void emit_all_obj_dtors();
 
     // Create an alloca, register its element type, and define it in the current scope
     llvm::Value* make_alloca(llvm::Type* t, const std::string& name);

--- a/src/lexer/dux.l
+++ b/src/lexer/dux.l
@@ -123,6 +123,7 @@ ALNUM   [a-zA-Z0-9_]
 "get"        { need_semi = true;  return yy::parser::make_KW_GET(loc);       }
 "set"        { need_semi = true;  return yy::parser::make_KW_SET(loc);       }
 "assert"     { need_semi = false; return yy::parser::make_KW_ASSERT(loc);    }
+"defer"      { need_semi = false; return yy::parser::make_KW_DEFER(loc);     }
 "and"        { need_semi = false; return yy::parser::make_KW_AND(loc);       }
 "or"         { need_semi = false; return yy::parser::make_KW_OR(loc);        }
 "not"        { need_semi = false; return yy::parser::make_KW_NOT(loc);       }

--- a/src/parser/dux.y
+++ b/src/parser/dux.y
@@ -79,7 +79,7 @@ static std::unique_ptr<T> mk(Args&&... a) {
 %token KW_TRY KW_CATCH KW_IN
 %token KW_CONST KW_STATIC
 %token KW_GET KW_SET
-%token KW_ASSERT
+%token KW_ASSERT KW_DEFER
 %token KW_AND KW_OR KW_NOT
 
 /* Type keywords */
@@ -143,7 +143,7 @@ static std::unique_ptr<T> mk(Args&&... a) {
 %type <StmtPtr>  stmt simple_stmt
 %type <StmtPtr>  if_stmt while_stmt do_while_stmt for_stmt
 %type <StmtPtr>  switch_stmt try_stmt return_stmt break_stmt
-%type <StmtPtr>  continue_stmt assert_stmt delete_stmt
+%type <StmtPtr>  continue_stmt assert_stmt delete_stmt defer_stmt
 %type <std::unique_ptr<BlockStmt>>       block
 %type <std::vector<SwitchCase>>          switch_cases
 %type <SwitchCase>                       switch_case
@@ -637,6 +637,7 @@ stmt
     | continue_stmt       { $$ = std::move($1); }
     | assert_stmt         { $$ = std::move($1); }
     | delete_stmt         { $$ = std::move($1); }
+    | defer_stmt          { $$ = std::move($1); }
     | var_decl_stmt       { $$ = std::move($1); }
     | simple_stmt SEMI    { $$ = std::move($1); }
     ;
@@ -798,6 +799,16 @@ assert_stmt
 delete_stmt
     : KW_DELETE expr SEMI
         { auto s = mk<DeleteStmt>(); s->loc = sl(@$, driver); s->expr = std::move($2); $$ = std::move(s); }
+    ;
+
+/* -- Defer ------------------------------------------------------------- */
+defer_stmt
+    : KW_DEFER LBRACE stmt_list RBRACE
+        {
+            auto s = mk<DeferStmt>(); s->loc = sl(@$, driver);
+            s->body = std::move($3);
+            $$ = std::move(s);
+        }
     ;
 
 /* -- Variable declaration ---------------------------------------------- */

--- a/src/sema/sema.cpp
+++ b/src/sema/sema.cpp
@@ -393,8 +393,8 @@ void Sema::check_stmt(const ast::Stmt& s) {
     }
     if (auto* a  = dynamic_cast<const ast::AssertStmt*>(&s))    { check_assert(*a);   return; }
     if (auto* d  = dynamic_cast<const ast::DeleteStmt*>(&s))    { check_delete(*d);   return; }
-    // LabeledStmt, etc. — visit the inner stmt
     if (auto* ls = dynamic_cast<const ast::LabeledStmt*>(&s))   { check_stmt(*ls->stmt); return; }
+    if (auto* ds = dynamic_cast<const ast::DeferStmt*>(&s))     { check_stmts(ds->body); return; }
 }
 
 void Sema::check_block(const ast::BlockStmt& b) {

--- a/tests/run_ok/defer_basic.dux
+++ b/tests/run_ok/defer_basic.dux
@@ -1,0 +1,34 @@
+class Logger {
+    str tag
+    Logger(str t) {
+        this.tag = t
+    }
+    ~Logger() {
+        println("dtor:" + this.tag)
+    }
+}
+
+void test_defer_order() {
+    defer {
+        println("defer:first")
+    }
+    defer {
+        println("defer:second")
+    }
+    println("body")
+}
+
+void test_defer_with_raii() {
+    Logger a = new Logger("a")
+    defer {
+        println("defer:between")
+    }
+    Logger b = new Logger("b")
+    println("inner")
+}
+
+int main() {
+    test_defer_order()
+    test_defer_with_raii()
+    return 0
+}

--- a/tests/run_ok/defer_basic.expected
+++ b/tests/run_ok/defer_basic.expected
@@ -1,0 +1,7 @@
+body
+defer:second
+defer:first
+inner
+dtor:b
+defer:between
+dtor:a


### PR DESCRIPTION
- Add DeferStmt AST node with a StmtList body (block form only)
- Lexer: KW_DEFER token; parser: KW_DEFER LBRACE stmt_list RBRACE rule
- Unify RAII and defer cleanup into a single ScopeCleanup stack (replaces split obj_scopes_ / emit_all_obj_dtors approach):
  * alloca+class_name entry = RAII destructor call at scope exit
  * defer_body entry = inline statement list at scope exit
- emit_scope_cleanup() dispatches to emit_dtor() or gen_stmts() accordingly
- emit_all_scope_cleanups() iterates all active scopes in LIFO order for explicit return paths; env_pop() handles implicit falls-off-end
- gen_defer() registers the defer body in the current scope's cleanup list
- Sema: type-check statements inside defer bodies
- Block-only syntax avoids grammar ambiguity with dict literals ({k:v})
- Test: defer_basic.dux verifies LIFO ordering across defer+RAII in same scope

Closes #66