### PR TITLE
fix(codegen): replace llvm::cast with dynamic_cast for AST BlockStmt

### DIFF
--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -1132,7 +1132,7 @@ void Codegen::gen_try_catch(const ast::TryCatchStmt& s) {
     env_push();
     lp_stack_.push_back(lp_bb);
 
-    auto* try_body_block = llvm::cast<ast::BlockStmt>(s.try_body.get());
+    auto* try_body_block = dynamic_cast<ast::BlockStmt*>(s.try_body.get());
     gen_stmts(try_body_block->body);
 
     lp_stack_.pop_back();


### PR DESCRIPTION
AST nodes don't implement classof(), so llvm::cast cannot be used on them. Use dynamic_cast consistently with the rest of the codebase.