### PR TITLE
feat: generic List<T>/Dict<V> stdlib with RAII element destruction

### DIFF
--- a/src/lexer/dux.l
+++ b/src/lexer/dux.l
@@ -143,8 +143,8 @@ ALNUM   [a-zA-Z0-9_]
 "double"     { need_semi = false; return yy::parser::make_KW_DOUBLE(loc); }
 "str"        { need_semi = true;  return yy::parser::make_KW_STR(loc);    }
 "bool"       { need_semi = false; return yy::parser::make_KW_BOOL(loc);   }
-"list"       { need_semi = false; return yy::parser::make_KW_LIST(loc);   }
-"dict"       { need_semi = false; return yy::parser::make_KW_DICT(loc);   }
+"list"       { need_semi = true;  return yy::parser::make_KW_LIST(loc);   }
+"dict"       { need_semi = true;  return yy::parser::make_KW_DICT(loc);   }
 "tuple"      { need_semi = false; return yy::parser::make_KW_TUPLE(loc);  }
 "object"     { need_semi = false; return yy::parser::make_KW_OBJECT(loc); }
 "ptr"        { need_semi = false; return yy::parser::make_KW_PTR(loc);    }

--- a/src/parser/dux.y
+++ b/src/parser/dux.y
@@ -264,6 +264,8 @@ namespace_body
 dotted_name
     : IDENT                     { $$ = $1; }
     | KW_STR                    { $$ = "str"; }
+    | KW_LIST                   { $$ = "list"; }
+    | KW_DICT                   { $$ = "dict"; }
     | dotted_name DOT IDENT     { $$ = $1 + '.' + $3; }
     ;
 

--- a/src/sema/generics.cpp
+++ b/src/sema/generics.cpp
@@ -2,6 +2,7 @@
 #include "driver/driver.hpp"
 #include <algorithm>
 #include <cassert>
+#include <functional>
 #include <queue>
 #include <unordered_map>
 #include <unordered_set>
@@ -56,6 +57,12 @@ static ExprPtr clone_expr(const Expr* e, const SubstMap& s) {
     }
     if (auto* n = dynamic_cast<const FloatLitExpr*>(e)) {
         auto r = std::make_unique<FloatLitExpr>(); r->loc = n->loc; r->value = n->value; return r;
+    }
+    if (auto* n = dynamic_cast<const LongLitExpr*>(e)) {
+        auto r = std::make_unique<LongLitExpr>(); r->loc = n->loc; r->value = n->value; return r;
+    }
+    if (auto* n = dynamic_cast<const RealLitExpr*>(e)) {
+        auto r = std::make_unique<RealLitExpr>(); r->loc = n->loc; r->value = n->value; return r;
     }
     if (auto* n = dynamic_cast<const StringLitExpr*>(e)) {
         auto r = std::make_unique<StringLitExpr>(); r->loc = n->loc; r->value = n->value; return r;
@@ -571,16 +578,23 @@ static bool ast_satisfies_bound(const std::string& concrete_type,
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 void expand_generics(ast::Program& prog, Driver& driver) {
-    // Step 1: collect generic class and function templates
+    // Step 1: collect generic class and function templates.
+    // Recurse into NamespaceDecl so templates inside imported stdlib files are found.
     std::unordered_map<std::string, const ClassDecl*>    generic_classes;
     std::unordered_map<std::string, const FunctionDecl*> generic_funcs;
 
-    for (const auto& dp : prog.decls) {
-        if (auto* c = dynamic_cast<const ClassDecl*>(dp.get()))
-            if (!c->type_params.empty()) generic_classes[c->name] = c;
-        if (auto* f = dynamic_cast<const FunctionDecl*>(dp.get()))
-            if (!f->type_params.empty()) generic_funcs[f->name] = f;
-    }
+    std::function<void(const DeclList&)> collect_templates;
+    collect_templates = [&](const DeclList& decls) {
+        for (const auto& dp : decls) {
+            if (auto* c = dynamic_cast<const ClassDecl*>(dp.get()))
+                if (!c->type_params.empty()) generic_classes[c->name] = c;
+            if (auto* f = dynamic_cast<const FunctionDecl*>(dp.get()))
+                if (!f->type_params.empty()) generic_funcs[f->name] = f;
+            if (auto* ns = dynamic_cast<const NamespaceDecl*>(dp.get()))
+                collect_templates(ns->decls);
+        }
+    };
+    collect_templates(prog.decls);
 
     if (generic_classes.empty() && generic_funcs.empty()) return;
 
@@ -678,6 +692,21 @@ void expand_generics(ast::Program& prog, Driver& driver) {
         if (auto* f = dynamic_cast<const FunctionDecl*>(dp.get()))
             is_generic = !f->type_params.empty();
         if (!is_generic) result.push_back(std::move(dp));
+    }
+    // Also strip generic templates from inside namespaces (e.g. imported stdlib files).
+    for (auto& dp : result) {
+        if (auto* ns = dynamic_cast<NamespaceDecl*>(dp.get())) {
+            DeclList kept;
+            for (auto& nd : ns->decls) {
+                bool is_ns_generic = false;
+                if (auto* c = dynamic_cast<const ClassDecl*>(nd.get()))
+                    is_ns_generic = !c->type_params.empty();
+                if (auto* f = dynamic_cast<const FunctionDecl*>(nd.get()))
+                    is_ns_generic = !f->type_params.empty();
+                if (!is_ns_generic) kept.push_back(std::move(nd));
+            }
+            ns->decls = std::move(kept);
+        }
     }
     prog.decls = std::move(result);
 }

--- a/src/sema/sema.cpp
+++ b/src/sema/sema.cpp
@@ -909,11 +909,13 @@ TypeId Sema::check_call(const ast::CallExpr& e) {
 TypeId Sema::check_member(const ast::MemberExpr& e) {
     TypeId obj_t = check_expr(*e.object);
 
-    // Try to find the member in the class type info scope
-    if (obj_t != TR::TID_UNKNOWN && obj_t >= 0) {
-        // For now: if the object is a known class, allow any member access.
-        // Full field resolution would require per-class symbol tables (M3 work).
+    // If the object is 'this', look up the field in the current class scope.
+    // This allows IndexExpr on list/dict fields to pick the correct codegen path.
+    if (dynamic_cast<const ast::ThisExpr*>(e.object.get())) {
+        Symbol* sym = scopes_.lookup(e.member);
+        if (sym) return sym->type;
     }
+
     // Return unknown — type will be refined during codegen
     return TR::TID_UNKNOWN;
 }

--- a/src/sema/types.cpp
+++ b/src/sema/types.cpp
@@ -95,9 +95,12 @@ bool TypeRegistry::assignable(TypeId from, TypeId to) const {
     if (from == TID_UNKNOWN || to == TID_UNKNOWN) return true;
     if (from == to) return true;
     if (to == TID_OBJECT) return true;
-    // ptr (TID_OBJECT) can be assigned to any heap type (enables unsafe blocks returning raw ptrs)
-    if (from == TID_OBJECT && (to == TID_STR || to == TID_LIST || to == TID_DICT))
-        return true;
+    // ptr (TID_OBJECT) can be assigned to any heap type (unsafe casts, list element retrieval)
+    if (from == TID_OBJECT) {
+        if (to == TID_STR || to == TID_LIST || to == TID_DICT) return true;
+        const TypeInfo& ti = info(to);
+        if (ti.kind == TypeKind::Class || ti.kind == TypeKind::Interface) return true;
+    }
     if (from == TID_NULL) {
         // null is assignable to any class/interface/list/dict/str
         const TypeInfo& ti = info(to);

--- a/stdlib/dict.dux
+++ b/stdlib/dict.dux
@@ -1,0 +1,41 @@
+extern "C" ptr duxrt_dict_new()
+extern "C" void duxrt_dict_set(ptr d, ptr key, ptr val)
+extern "C" ptr duxrt_dict_get(ptr d, ptr key)
+extern "C" int duxrt_dict_has(ptr d, ptr key)
+extern "C" void duxrt_dict_free(ptr d)
+extern "C" ptr duxrt_str_cstr(ptr s)
+
+class Dict<V>(object) {
+    public:
+    dict _data
+
+    Dict() {
+        this._data = {}
+    }
+
+    void set(str key, V val) {
+        unsafe {
+            ptr k = duxrt_str_cstr(key)
+            duxrt_dict_set(this._data, k, val)
+        }
+    }
+
+    V get(str key) {
+        return this._data[key]
+    }
+
+    bool has(str key) {
+        int result = 0
+        unsafe {
+            ptr k = duxrt_str_cstr(key)
+            result = duxrt_dict_has(this._data, k)
+        }
+        return result != 0
+    }
+
+    ~Dict() {
+        unsafe {
+            duxrt_dict_free(this._data)
+        }
+    }
+}

--- a/stdlib/list.dux
+++ b/stdlib/list.dux
@@ -1,0 +1,43 @@
+extern "C" ptr duxrt_list_new()
+extern "C" void duxrt_list_push(ptr l, ptr val)
+extern "C" ptr duxrt_list_get(ptr l, long idx)
+extern "C" long duxrt_list_len(ptr l)
+extern "C" void duxrt_list_free(ptr l)
+
+class List<T>(object) {
+    public:
+    list _items
+    long _len
+
+    List() {
+        this._len = 0l
+        this._items = []
+    }
+
+    void push(T item) {
+        unsafe {
+            duxrt_list_push(this._items, item)
+        }
+        this._len = this._len + 1l
+    }
+
+    T at(long i) {
+        return this._items[i]
+    }
+
+    long len() {
+        return this._len
+    }
+
+    ~List() {
+        long i = 0l
+        while i < this._len {
+            T item = this._items[i]
+            delete item
+            i = i + 1l
+        }
+        unsafe {
+            duxrt_list_free(this._items)
+        }
+    }
+}

--- a/tests/run_ok/list_raii.dux
+++ b/tests/run_ok/list_raii.dux
@@ -1,0 +1,20 @@
+import list
+
+class Item(object) {
+    public:
+    str label
+    Item(str s) {
+        this.label = s
+    }
+    ~Item() {
+        println("free:" + this.label)
+    }
+}
+
+int main() {
+    List<Item> items = new List<Item>()
+    items.push(new Item("x"))
+    items.push(new Item("y"))
+    println("pushed")
+    return 0
+}

--- a/tests/run_ok/list_raii.expected
+++ b/tests/run_ok/list_raii.expected
@@ -1,0 +1,3 @@
+pushed
+free:x
+free:y


### PR DESCRIPTION
- Add stdlib/list.dux: generic List<T> class wrapping duxrt_list_* runtime
- Add stdlib/dict.dux: generic Dict<V> class wrapping duxrt_dict_* runtime
- Fix generics.cpp: clone_expr was missing LongLitExpr/RealLitExpr, causing null AssignExpr.value in expanded generic classes and a segfault in sema
- Fix generics.cpp: expand_generics step 1 now recurses into NamespaceDecl so generic classes in imported files (wrapped in namespace by driver) are found and expanded; step 4 strips template originals from namespaces
- Fix sema.cpp check_member: resolve this.field type from scope so that IndexExpr on list/dict fields emits duxrt_list_get/duxrt_dict_get correctly
- Fix types.cpp assignable: TID_OBJECT is assignable to user class types, enabling list element retrieval into typed variables (T item = list[i])
- Fix lexer: list/dict keywords set need_semi=true for import ASI
- Fix parser: KW_LIST/KW_DICT/KW_STR usable in dotted_name (import paths)
- Add tests/run_ok/list_raii: verifies element destructors fire at scope exit