### PR TITLE
fix: address critical and high-severity compiler/runtime bugs

### DIFF
--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -985,10 +985,17 @@ void Codegen::gen_stmt(const ast::Stmt& s) {
         if (loop_stack_.empty()) return;
         if (br->label) {
             for (auto it = loop_stack_.rbegin(); it != loop_stack_.rend(); ++it)
-                if (it->label == *br->label) { builder_->CreateBr(it->exit); return; }
+                if (it->label == *br->label) {
+                    emit_all_scope_cleanups();
+                    emit_all_str_releases();
+                    builder_->CreateBr(it->exit);
+                    return;
+                }
             err(br->loc, "label '" + *br->label + "' not found for break");
             return;
         }
+        emit_all_scope_cleanups();
+        emit_all_str_releases();
         builder_->CreateBr(loop_stack_.back().exit);
         return;
     }
@@ -996,10 +1003,17 @@ void Codegen::gen_stmt(const ast::Stmt& s) {
         if (loop_stack_.empty()) return;
         if (co->label) {
             for (auto it = loop_stack_.rbegin(); it != loop_stack_.rend(); ++it)
-                if (it->label == *co->label) { builder_->CreateBr(it->header); return; }
+                if (it->label == *co->label) {
+                    emit_all_scope_cleanups();
+                    emit_all_str_releases();
+                    builder_->CreateBr(it->header);
+                    return;
+                }
             err(co->loc, "label '" + *co->label + "' not found for continue");
             return;
         }
+        emit_all_scope_cleanups();
+        emit_all_str_releases();
         builder_->CreateBr(loop_stack_.back().header);
         return;
     }
@@ -1364,7 +1378,10 @@ void Codegen::gen_match(const ast::MatchStmt& s) {
     }
 
     auto* exit_bb = BasicBlock::Create(*ctx_, "match.end", fn);
-    BasicBlock* default_bb = exit_bb; // default goes to exit unless overridden
+
+    // No wildcard: generate an unreachable trap for non-exhaustive match
+    auto* trap_bb = BasicBlock::Create(*ctx_, "match.trap", fn);
+    BasicBlock* default_bb = nullptr;
 
     // Collect non-wildcard arms for switch, find wildcard arm
     const ast::MatchArm* wildcard_arm = nullptr;
@@ -1398,9 +1415,11 @@ void Codegen::gen_match(const ast::MatchStmt& s) {
         }
     }
 
-    // Build wildcard block if any
+    // Build wildcard block if any; otherwise fall through to trap
     if (wildcard_arm) {
         default_bb = BasicBlock::Create(*ctx_, "match.wildcard", fn);
+    } else {
+        default_bb = trap_bb;
     }
 
     auto* sw = builder_->CreateSwitch(match_val, default_bb,
@@ -1430,6 +1449,14 @@ void Codegen::gen_match(const ast::MatchStmt& s) {
             builder_->CreateBr(exit_bb);
     }
 
+    // Emit trap block (reached when match is not exhaustive)
+    builder_->SetInsertPoint(trap_bb);
+    {
+        auto* trap_fn = llvm::Intrinsic::getDeclaration(mod_.get(), llvm::Intrinsic::trap);
+        builder_->CreateCall(trap_fn, {});
+        builder_->CreateUnreachable();
+    }
+
     builder_->SetInsertPoint(exit_bb);
 }
 
@@ -1453,7 +1480,10 @@ void Codegen::gen_try_catch(const ast::TryCatchStmt& s) {
     auto* try_body_block = dynamic_cast<ast::BlockStmt*>(s.try_body.get());
     gen_stmts(try_body_block->body);
 
-    lp_stack_.pop_back();
+    // Do NOT pop lp_stack_ yet — the LP block cleanup code below calls
+    // emit_all_scope_cleanups(), which must emit invoke (not plain call)
+    // so that a throw inside a defer/dtor is covered by the landingpad
+    // itself (R-3 fix: lp_stack_ stays live until after LP cleanup).
 
     // Save the normal-path exit block before switching to the LP.
     auto* try_exit_bb = builder_->GetInsertBlock();
@@ -1470,8 +1500,9 @@ void Codegen::gen_try_catch(const ast::TryCatchStmt& s) {
                            llvm::cast<llvm::PointerType>(ptr_type())));
 
     // RAII + defer cleanup on the unwind path (objects still in scope).
-    emit_all_scope_cleanups();
+    emit_all_scope_cleanups();  // still have lp in stack so nested throws are covered
     emit_all_str_releases();
+    lp_stack_.pop_back();       // NOW pop, after cleanup is done (R-3 fix)
 
     // __cxa_begin_catch: resolve the thrown object.
     Value* exc_lp_ptr = builder_->CreateExtractValue(lp_inst, {0u}, "exc.lp");
@@ -1500,14 +1531,16 @@ void Codegen::gen_try_catch(const ast::TryCatchStmt& s) {
             builder_->CreateLoad(ptr_type(), exc_slot, "exc.v"), cv_alloca);
         env_define(*s.catch_var, cv_alloca);
     }
+    // Register __cxa_end_catch as a cleanup so it fires even when the catch
+    // body exits via return or rethrow (EH-3 fix).
+    llvm::Function* end_catch_fn = get_or_declare_rt(
+        "__cxa_end_catch", llvm::Type::getVoidTy(*ctx_), {});
+    cleanup_scopes_.back().push_back(
+        {nullptr, "", nullptr, end_catch_fn});
     gen_stmt(*s.catch_body);
-    if (!builder_->GetInsertBlock()->getTerminator()) {
-        auto* end_catch = get_or_declare_rt("__cxa_end_catch",
-                              llvm::Type::getVoidTy(*ctx_), {});
-        builder_->CreateCall(end_catch, {});
+    env_pop();  // env_pop fires emit_scope_cleanup which calls __cxa_end_catch
+    if (!builder_->GetInsertBlock()->getTerminator())
         builder_->CreateBr(end_bb);
-    }
-    env_pop();
 
     builder_->SetInsertPoint(end_bb);
 }
@@ -2802,7 +2835,7 @@ void Codegen::emit_dtor(Value* alloca, const std::string& class_name) {
     builder_->CreateCondBr(is_null, end_bb, call_bb);
 
     builder_->SetInsertPoint(call_bb);
-    builder_->CreateCall(dtor_fn, {obj_ptr});
+    emit_call(dtor_fn, {obj_ptr});
     builder_->CreateCall(free_fn, {obj_ptr});
     // Null out the slot so a second emit_dtor call is a no-op.
     builder_->CreateStore(null_v, alloca);
@@ -2814,10 +2847,13 @@ void Codegen::emit_dtor(Value* alloca, const std::string& class_name) {
 void Codegen::emit_scope_cleanup(const ScopeCleanup& c) {
     auto* bb = builder_->GetInsertBlock();
     if (!bb || bb->getTerminator()) return;
-    if (c.defer_body)
+    if (c.fn_to_call) {
+        emit_call(c.fn_to_call, {});
+    } else if (c.defer_body) {
         gen_stmts(*c.defer_body);
-    else
+    } else {
         emit_dtor(c.alloca, c.class_name);
+    }
 }
 
 void Codegen::emit_all_scope_cleanups() {

--- a/src/codegen/codegen.hpp
+++ b/src/codegen/codegen.hpp
@@ -129,6 +129,7 @@ private:
     // Each entry is one of:
     //   - Class RAII dtor:  alloca != nullptr, defer_body == nullptr
     //   - Defer block:      alloca == nullptr, defer_body != nullptr
+    //   - C cleanup fn:     fn_to_call != nullptr
     //
     // Entries within a scope are processed in reverse-declaration order
     // (LIFO) so that later declarations are destroyed first, matching
@@ -137,6 +138,7 @@ private:
         llvm::Value*          alloca{nullptr};      // RAII: alloca holding heap ptr
         std::string           class_name;            // RAII: destructor symbol prefix
         const ast::StmtList*  defer_body{nullptr};  // defer: statements to run
+        llvm::Function*       fn_to_call{nullptr};  // new: no-arg cleanup function
     };
     std::vector<std::vector<ScopeCleanup>> cleanup_scopes_;
 

--- a/src/runtime/dict.c
+++ b/src/runtime/dict.c
@@ -30,6 +30,7 @@ DuxDict* duxrt_dict_new(void) {
     if (!d) abort();
     d->len  = 0;
     d->cap  = DICT_INIT_CAP;
+    d->tomb = 0;
     d->entries = (DuxDictEntry*)calloc((size_t)DICT_INIT_CAP, sizeof(DuxDictEntry));
     if (!d->entries) abort();
     return d;
@@ -63,6 +64,7 @@ static void dict_grow(DuxDict* d) {
     DuxDictEntry* old_ents = d->entries;
     d->cap    *= 2;
     d->len     = 0;
+    d->tomb    = 0;   /* tombstones are cleared on resize */
     d->entries = (DuxDictEntry*)calloc((size_t)d->cap, sizeof(DuxDictEntry));
     if (!d->entries) abort();
     for (int64_t i = 0; i < old_cap; ++i) {
@@ -75,7 +77,7 @@ static void dict_grow(DuxDict* d) {
 
 void duxrt_dict_set(DuxDict* d, const char* key, void* val) {
     if (!d || !key) return;
-    if (d->len * DICT_LOAD_DEN >= d->cap * DICT_LOAD_NUM)
+    if ((d->len + d->tomb) * DICT_LOAD_DEN >= d->cap * DICT_LOAD_NUM)
         dict_grow(d);
     char* k = strdup(key);
     if (!k) abort();
@@ -119,6 +121,7 @@ void duxrt_dict_del(DuxDict* d, const char* key) {
             d->entries[idx].key = TOMBSTONE;  /* mark deleted; preserve probe chain */
             d->entries[idx].val = NULL;
             d->len--;
+            d->tomb++;
             return;
         }
         idx = (idx + 1) & (d->cap - 1);

--- a/src/runtime/duxrt.h
+++ b/src/runtime/duxrt.h
@@ -6,6 +6,16 @@
 #include <stdint.h>
 #include <stddef.h>
 
+/* _Atomic is C11; in C++ mode use a compatibility shim so this header
+ * can be included from both C and C++ translation units.                */
+#ifdef __cplusplus
+#  include <atomic>
+#  define DUXRT_ATOMIC(T) std::atomic<T>
+#else
+#  include <stdatomic.h>
+#  define DUXRT_ATOMIC(T) _Atomic T
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -56,7 +66,7 @@ void  duxrt_print_double(double v);
 #define DUXSTR_INLINE_MAX  63   /* strings <= 63 bytes are stored inline (FAM) */
 
 typedef struct DuxStr {
-    int32_t  refcount;
+    DUXRT_ATOMIC(int32_t)  refcount;
     int32_t  len;    /* int32_t: no padding after refcount → header = 16 bytes */
     char*    ext;    /* NULL  → data inline in FAM below (short strings)
                         non-NULL → separate heap buffer    (long strings)  */
@@ -135,6 +145,7 @@ typedef struct DuxDictEntry {
 typedef struct DuxDict {
     int64_t       len;
     int64_t       cap;
+    int64_t       tomb;
     DuxDictEntry* entries;
 } DuxDict;
 

--- a/src/runtime/file_rt.c
+++ b/src/runtime/file_rt.c
@@ -37,6 +37,9 @@ DuxList* duxrt_file_read_lines(DuxStr* path) {
         if (n > 0 && line[n - 1] == '\n') { line[n - 1] = '\0'; n--; }
         duxrt_list_push(list, duxrt_str_new(line, (int64_t)n));
     }
+    if (ferror(f)) {
+        fputs("duxrt: read error in duxrt_file_read_lines\n", stderr);
+    }
     free(line);
     fclose(f);
     return list;

--- a/src/runtime/json_rt.c
+++ b/src/runtime/json_rt.c
@@ -153,7 +153,7 @@ DuxStr* duxrt_json_stringify(void* handle) {
     buf[pos++] = '{';
     int first = 1;
     for (int64_t i = 0; i < d->cap; i++) {
-        if (!d->entries[i].key) continue;
+        if (!d->entries[i].key || d->entries[i].key == (char*)(uintptr_t)1) continue;
         const char* k = d->entries[i].key;
         DuxStr* vs = (DuxStr*)d->entries[i].val;
         const char* v = vs ? duxrt_str_cstr(vs) : "";

--- a/src/runtime/str.c
+++ b/src/runtime/str.c
@@ -35,13 +35,13 @@ DuxStr* duxrt_str_new(const char* src, int64_t len) {
 }
 
 DuxStr* duxrt_str_retain(DuxStr* s) {
-    if (s && s->refcount != -1) s->refcount++;
+    if (s && atomic_load(&s->refcount) != -1) atomic_fetch_add(&s->refcount, 1);
     return s;
 }
 
 void duxrt_str_release(DuxStr* s) {
-    if (!s || s->refcount == -1) return;   /* null or immortal */
-    if (--s->refcount == 0) {
+    if (!s || atomic_load(&s->refcount) == -1) return;   /* null or immortal */
+    if (atomic_fetch_sub(&s->refcount, 1) == 1) {
         if (s->ext) free(s->ext);          /* long strings: free external buffer */
         free(s);                            /* always: free the header */
     }

--- a/src/runtime/thread_rt.c
+++ b/src/runtime/thread_rt.c
@@ -34,14 +34,20 @@ static void* thread_runner(void* arg) {
     return NULL;
 }
 
+typedef struct {
+    pthread_t tid;
+    int       joined;
+} DuxThread;
+
 void* duxrt_thread_spawn(void* fn, void* arg) {
-    pthread_t* t = (pthread_t*)malloc(sizeof(pthread_t));
+    DuxThread* t = (DuxThread*)malloc(sizeof(DuxThread));
     if (!t) return NULL;
+    t->joined = 0;
     ThreadArgs* ta = (ThreadArgs*)malloc(sizeof(ThreadArgs));
     if (!ta) { free(t); return NULL; }
     ta->fn  = (void (*)(void*))fn;
     ta->arg = arg;
-    if (pthread_create(t, NULL, thread_runner, ta) != 0) {
+    if (pthread_create(&t->tid, NULL, thread_runner, ta) != 0) {
         free(ta); free(t); return NULL;
     }
     return t;
@@ -49,17 +55,19 @@ void* duxrt_thread_spawn(void* fn, void* arg) {
 
 int32_t duxrt_thread_join(void* handle) {
     if (!handle) return -1;
-    pthread_t* t = (pthread_t*)handle;
-    int r = pthread_join(*t, NULL);
-    free(t);
+    DuxThread* t = (DuxThread*)handle;
+    if (t->joined) return -1;
+    int r = pthread_join(t->tid, NULL);
+    if (r == 0) t->joined = 1;
     return r == 0 ? 0 : -1;
 }
 
 int32_t duxrt_thread_detach(void* handle) {
     if (!handle) return -1;
-    pthread_t* t = (pthread_t*)handle;
-    int r = pthread_detach(*t);
-    free(t);
+    DuxThread* t = (DuxThread*)handle;
+    if (t->joined) return -1;
+    int r = pthread_detach(t->tid);
+    if (r == 0) t->joined = 1;
     return r == 0 ? 0 : -1;
 }
 
@@ -161,19 +169,16 @@ void duxrt_cond_free(void* c) {
 /* ── Once ────────────────────────────────────────────────────────────────── */
 
 typedef struct {
-    pthread_once_t once;
-    void (*fn)(void);
+    pthread_mutex_t mu;
+    int             done;
+    void           (*fn)(void);
 } DuxOnce;
-
-/* pthread_once requires a static/global function — we store the fn ptr in TLS */
-static __thread void (*once_fn_)(void) = NULL;
-static void once_trampoline(void) { if (once_fn_) once_fn_(); }
 
 void* duxrt_once_new(void) {
     DuxOnce* o = (DuxOnce*)malloc(sizeof(DuxOnce));
     if (!o) return NULL;
-    pthread_once_t init = PTHREAD_ONCE_INIT;
-    o->once = init;
+    pthread_mutex_init(&o->mu, NULL);
+    o->done = 0;
     o->fn   = NULL;
     return o;
 }
@@ -181,10 +186,18 @@ void* duxrt_once_new(void) {
 void duxrt_once_call(void* handle, void* fn) {
     DuxOnce* o = (DuxOnce*)handle;
     if (!o || !fn) return;
-    once_fn_ = (void (*)(void))fn;
-    pthread_once(&o->once, once_trampoline);
+    pthread_mutex_lock(&o->mu);
+    if (!o->done) {
+        o->fn = (void (*)(void))fn;
+        o->fn();
+        o->done = 1;
+    }
+    pthread_mutex_unlock(&o->mu);
 }
 
 void duxrt_once_free(void* handle) {
-    free(handle);
+    if (!handle) return;
+    DuxOnce* o = (DuxOnce*)handle;
+    pthread_mutex_destroy(&o->mu);
+    free(o);
 }


### PR DESCRIPTION
Codegen fixes (src/codegen/):
- EH-2: emit_dtor now uses emit_call() instead of CreateCall() so that destructor calls inside a try block are routed through the landing pad when they throw, rather than bypassing it.
- EH-3: register __cxa_end_catch as a ScopeCleanup fn_to_call entry at the start of the catch scope so env_pop() fires it reliably even when the catch body exits via return or rethrow, not only on fall-through. Added fn_to_call field to ScopeCleanup struct in codegen.hpp.
- R-2: break and continue (labeled and unlabeled) now call emit_all_scope_cleanups() and emit_all_str_releases() before the branch so RAII dtors and defer blocks inside loop bodies are run.
- R-3: lp_stack_.pop_back() moved from immediately after gen_stmts() to after emit_all_scope_cleanups()/emit_all_str_releases() in the landing-pad block, so cleanup invocations during LP handling are themselves covered by the landing pad.
- M-2: gen_match emits a 'match.trap' basic block (llvm.trap + unreachable) as the switch default when no wildcard arm is present, catching non-exhaustive matches at runtime instead of silently falling through to exit_bb.

Runtime fixes (src/runtime/):
- RT-1 (str.c): duxrt_str_retain/release use atomic_fetch_add/sub and atomic_load for thread-safe refcounting on DuxStr.
- RT-2 (thread_rt.c): DuxThread struct wraps pthread_t with a 'joined' flag; duxrt_thread_join/detach check and set it to prevent double-join/detach.
- RT-3 (dict.c): DuxDict gains a 'tomb' field tracking tombstone slots; resize triggers on (len+tomb)*LOAD_DEN >= cap*LOAD_NUM so tombstone accumulation does not stall the table at low occupancy.
- RT-4 (json_rt.c): duxrt_json_stringify skips tombstone entries (key == TOMBSTONE sentinel) when serialising dict contents.
- RT-7 (thread_rt.c): DuxOnce replaces the TLS-based pthread_once trampoline with a plain mutex+done flag so the fn pointer is not stored in TLS, eliminating the thread-safety race on once_fn_.
- RT-9 (file_rt.c): duxrt_file_read_lines checks ferror() after the read loop and reports I/O errors to stderr.
- duxrt.h: DUXRT_ATOMIC(T) macro replaces bare _Atomic so the header compiles cleanly from both C11 and C++ translation units.

All 140 tests pass.

https://claude.ai/code/session_013268REeAo1j62C7yC5BB9P