### PR TITLE
feat(stdlib): async cooperative task model — Phase 1 (#110)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ add_library(duxrt STATIC
     src/runtime/socket_rt.c
     src/runtime/net_tls.c
     src/runtime/net_http.c
+    src/runtime/async_rt.c
+    src/runtime/achan_rt.c
 )
 
 target_include_directories(duxrt PUBLIC src/runtime)

--- a/src/runtime/achan_rt.c
+++ b/src/runtime/achan_rt.c
@@ -1,0 +1,164 @@
+/*
+ * achan_rt.c — non-blocking ring-buffer async channels
+ *
+ * AsyncChan is a fixed-capacity ring buffer protected by a mutex.
+ * - try_send / try_recv are non-blocking (return immediately).
+ * - send / recv are blocking (wait using condvars).
+ * - Sending to a closed channel is a no-op.
+ * - Receiving from a closed, empty channel returns NULL.
+ *
+ * All public symbols are prefixed duxrt_achan_ to avoid collisions with
+ * the blocking thread channels (duxrt_chan_*).
+ */
+#include "duxrt.h"
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct AchanBuf {
+    void**          buf;        /* ring-buffer storage          */
+    int64_t         cap;        /* buffer capacity (> 0)        */
+    int64_t         head;       /* next write slot              */
+    int64_t         tail;       /* next read  slot              */
+    int64_t         len;        /* number of items in buffer    */
+    int             closed;
+    pthread_mutex_t mu;
+    pthread_cond_t  not_empty;
+    pthread_cond_t  not_full;
+} AchanBuf;
+
+/* ── Lifecycle ───────────────────────────────────────────────────────────── */
+
+void* duxrt_achan_new(int64_t cap) {
+    if (cap <= 0) cap = 1;
+    AchanBuf* c = (AchanBuf*)calloc(1, sizeof(AchanBuf));
+    if (!c) return NULL;
+    c->buf = (void**)calloc((size_t)cap, sizeof(void*));
+    if (!c->buf) { free(c); return NULL; }
+    c->cap = cap;
+    pthread_mutex_init(&c->mu, NULL);
+    pthread_cond_init(&c->not_empty, NULL);
+    pthread_cond_init(&c->not_full, NULL);
+    return c;
+}
+
+void duxrt_achan_free(void* ch) {
+    AchanBuf* c = (AchanBuf*)ch;
+    if (!c) return;
+    pthread_mutex_destroy(&c->mu);
+    pthread_cond_destroy(&c->not_empty);
+    pthread_cond_destroy(&c->not_full);
+    free(c->buf);
+    free(c);
+}
+
+/* ── Close ───────────────────────────────────────────────────────────────── */
+
+void duxrt_achan_close(void* ch) {
+    AchanBuf* c = (AchanBuf*)ch;
+    if (!c) return;
+    pthread_mutex_lock(&c->mu);
+    c->closed = 1;
+    pthread_cond_broadcast(&c->not_empty);
+    pthread_cond_broadcast(&c->not_full);
+    pthread_mutex_unlock(&c->mu);
+}
+
+int32_t duxrt_achan_is_closed(void* ch) {
+    AchanBuf* c = (AchanBuf*)ch;
+    if (!c) return 1;
+    pthread_mutex_lock(&c->mu);
+    int r = c->closed;
+    pthread_mutex_unlock(&c->mu);
+    return r;
+}
+
+/* ── Capacity / length ───────────────────────────────────────────────────── */
+
+int64_t duxrt_achan_len(void* ch) {
+    AchanBuf* c = (AchanBuf*)ch;
+    if (!c) return 0;
+    pthread_mutex_lock(&c->mu);
+    int64_t n = c->len;
+    pthread_mutex_unlock(&c->mu);
+    return n;
+}
+
+int64_t duxrt_achan_cap(void* ch) {
+    AchanBuf* c = (AchanBuf*)ch;
+    if (!c) return 0;
+    return c->cap; /* immutable — no lock needed */
+}
+
+/* ── Non-blocking send/recv ──────────────────────────────────────────────── */
+
+/* Returns 1 if the item was enqueued, 0 if the channel is full or closed. */
+int32_t duxrt_achan_try_send(void* ch, void* val) {
+    AchanBuf* c = (AchanBuf*)ch;
+    if (!c) return 0;
+    pthread_mutex_lock(&c->mu);
+    if (c->closed || c->len >= c->cap) {
+        pthread_mutex_unlock(&c->mu);
+        return 0;
+    }
+    c->buf[c->head] = val;
+    c->head = (c->head + 1) % c->cap;
+    c->len++;
+    pthread_cond_signal(&c->not_empty);
+    pthread_mutex_unlock(&c->mu);
+    return 1;
+}
+
+/* Returns the next item, or NULL if the channel is empty. */
+void* duxrt_achan_try_recv(void* ch) {
+    AchanBuf* c = (AchanBuf*)ch;
+    if (!c) return NULL;
+    pthread_mutex_lock(&c->mu);
+    if (c->len == 0) {
+        pthread_mutex_unlock(&c->mu);
+        return NULL;
+    }
+    void* val = c->buf[c->tail];
+    c->tail = (c->tail + 1) % c->cap;
+    c->len--;
+    pthread_cond_signal(&c->not_full);
+    pthread_mutex_unlock(&c->mu);
+    return val;
+}
+
+/* ── Blocking send/recv ──────────────────────────────────────────────────── */
+
+/* Blocks until space is available (or channel is closed). */
+void duxrt_achan_send(void* ch, void* val) {
+    AchanBuf* c = (AchanBuf*)ch;
+    if (!c) return;
+    pthread_mutex_lock(&c->mu);
+    while (!c->closed && c->len >= c->cap)
+        pthread_cond_wait(&c->not_full, &c->mu);
+    if (!c->closed) {
+        c->buf[c->head] = val;
+        c->head = (c->head + 1) % c->cap;
+        c->len++;
+        pthread_cond_signal(&c->not_empty);
+    }
+    pthread_mutex_unlock(&c->mu);
+}
+
+/* Blocks until an item is available. Returns NULL if closed+empty. */
+void* duxrt_achan_recv(void* ch) {
+    AchanBuf* c = (AchanBuf*)ch;
+    if (!c) return NULL;
+    pthread_mutex_lock(&c->mu);
+    while (c->len == 0 && !c->closed)
+        pthread_cond_wait(&c->not_empty, &c->mu);
+    if (c->len == 0) {
+        pthread_mutex_unlock(&c->mu);
+        return NULL;
+    }
+    void* val = c->buf[c->tail];
+    c->tail = (c->tail + 1) % c->cap;
+    c->len--;
+    pthread_cond_signal(&c->not_full);
+    pthread_mutex_unlock(&c->mu);
+    return val;
+}

--- a/src/runtime/async_rt.c
+++ b/src/runtime/async_rt.c
@@ -1,0 +1,66 @@
+/*
+ * async_rt.c — cooperative async scheduler runtime (Phase 1)
+ *
+ * Phase 1 provides:
+ *   - sleep_ms / yield  (time-based cooperative yield)
+ *   - run / stop        (event-loop control)
+ *
+ * Phase 2 will add async/await keywords and LLVM coroutine lowering.
+ * All public symbols are prefixed duxrt_async_ to avoid collisions.
+ */
+#include "duxrt.h"
+#include <sched.h>
+#include <time.h>
+#include <stdatomic.h>
+
+/* ── Global event-loop state ─────────────────────────────────────────────── */
+
+static _Atomic int g_stop_requested = 0;
+static _Atomic int g_running        = 0;
+
+/* ── Yield / sleep ───────────────────────────────────────────────────────── */
+
+void duxrt_async_sleep_ms(int64_t ms) {
+    if (ms <= 0) return;
+    struct timespec ts;
+    ts.tv_sec  = ms / 1000;
+    ts.tv_nsec = (ms % 1000) * 1000000L;
+    nanosleep(&ts, NULL);
+}
+
+void duxrt_async_yield(void) {
+    sched_yield();
+}
+
+/* ── Event loop ──────────────────────────────────────────────────────────── */
+
+/*
+ * run() — enter the event loop.
+ * Ticks every 1 ms until stop() is called.
+ * If stop() was called *before* run(), run() exits on the first check.
+ */
+void duxrt_async_run(void) {
+    atomic_store(&g_running, 1);
+
+    struct timespec tick = {0, 1000000L}; /* 1 ms per tick */
+    while (!atomic_load(&g_stop_requested)) {
+        nanosleep(&tick, NULL);
+    }
+
+    atomic_store(&g_running, 0);
+    atomic_store(&g_stop_requested, 0); /* reset so run() can be called again */
+}
+
+/*
+ * stop() — signal the event loop to exit.
+ * Safe to call before run() — run() will then return immediately.
+ */
+void duxrt_async_stop(void) {
+    atomic_store(&g_stop_requested, 1);
+    atomic_store(&g_running, 0);
+}
+
+/* Returns 1 while the event loop is executing duxrt_async_run(). */
+int32_t duxrt_async_is_running(void) {
+    return atomic_load(&g_running) ? 1 : 0;
+}

--- a/src/runtime/duxrt.h
+++ b/src/runtime/duxrt.h
@@ -479,6 +479,25 @@ void    duxrt_http_req_free(void* req);
 DuxStr* duxrt_http_format_response(int32_t status, DuxStr* status_text,
                                     void* headers_dict, DuxStr* body);
 
+/* ── Async scheduler (Phase 1) ───────────────────────────────────────────── */
+void    duxrt_async_sleep_ms(int64_t ms);
+void    duxrt_async_yield(void);
+void    duxrt_async_run(void);
+void    duxrt_async_stop(void);
+int32_t duxrt_async_is_running(void);
+
+/* ── Async non-blocking ring-buffer channels ─────────────────────────────── */
+void*   duxrt_achan_new(int64_t cap);
+void    duxrt_achan_free(void* ch);
+void    duxrt_achan_close(void* ch);
+int32_t duxrt_achan_is_closed(void* ch);
+int64_t duxrt_achan_len(void* ch);
+int64_t duxrt_achan_cap(void* ch);
+int32_t duxrt_achan_try_send(void* ch, void* val);  /* 1=sent, 0=full/closed */
+void*   duxrt_achan_try_recv(void* ch);              /* NULL if empty         */
+void    duxrt_achan_send(void* ch, void* val);       /* blocks until space    */
+void*   duxrt_achan_recv(void* ch);                  /* blocks; NULL=closed+empty */
+
 /* ── Exceptions ──────────────────────────────────────────────────────────── */
 typedef struct DuxException {
     const char* type_name;

--- a/stdlib/async/chan.dux
+++ b/stdlib/async/chan.dux
@@ -1,0 +1,121 @@
+# async.chan — non-blocking ring-buffer channels
+#
+# AsyncChan wraps a fixed-capacity ring buffer.
+# try_send / try_recv are non-blocking; send / recv block until ready.
+#
+# Usage: import async.chan
+
+namespace achan {
+    extern "C" ptr  duxrt_achan_new(long cap) ;
+    extern "C" void duxrt_achan_free(ptr ch) ;
+    extern "C" void duxrt_achan_close(ptr ch) ;
+    extern "C" int  duxrt_achan_is_closed(ptr ch) ;
+    extern "C" long duxrt_achan_len(ptr ch) ;
+    extern "C" long duxrt_achan_cap(ptr ch) ;
+    extern "C" int  duxrt_achan_try_send(ptr ch, ptr val) ;
+    extern "C" ptr  duxrt_achan_try_recv(ptr ch) ;
+    extern "C" void duxrt_achan_send(ptr ch, ptr val) ;
+    extern "C" ptr  duxrt_achan_recv(ptr ch) ;
+}
+
+# AsyncChan — a non-blocking, fixed-capacity ring-buffer channel.
+#
+# cap must be > 0.  Items are opaque pointers (ptr); the channel does not
+# manage the lifetime of the values it carries.
+#
+# Example:
+#   AsyncChan ch = new AsyncChan(8)
+#   bool ok = ch.try_send(null)   # non-blocking
+#   ptr  v  = ch.try_recv()       # null if empty
+#   ch.close()
+class AsyncChan {
+    ptr  _ch
+    bool _closed
+
+    AsyncChan(int cap) {
+        this._closed = false
+        unsafe {
+            this._ch = duxrt_achan_new(cap)
+        }
+    }
+
+    # Non-blocking send.
+    # Returns true if the item was queued, false if the buffer is full or closed.
+    bool try_send(ptr val) {
+        int r = 0
+        unsafe {
+            r = duxrt_achan_try_send(this._ch, val)
+        }
+        return r != 0
+    }
+
+    # Non-blocking receive.
+    # Returns the next item, or null if the channel is empty.
+    ptr try_recv() {
+        ptr r = null
+        unsafe {
+            r = duxrt_achan_try_recv(this._ch)
+        }
+        return r
+    }
+
+    # Blocking send — waits until there is space in the buffer.
+    # No-op if the channel is closed.
+    void send(ptr val) {
+        unsafe {
+            duxrt_achan_send(this._ch, val)
+        }
+    }
+
+    # Blocking receive — waits until an item is available.
+    # Returns null if the channel is closed and empty.
+    ptr recv() {
+        ptr r = null
+        unsafe {
+            r = duxrt_achan_recv(this._ch)
+        }
+        return r
+    }
+
+    # Number of items currently buffered.
+    long pending() {
+        long n = 0
+        unsafe {
+            n = duxrt_achan_len(this._ch)
+        }
+        return n
+    }
+
+    # Maximum capacity of the ring buffer.
+    long capacity() {
+        long n = 0
+        unsafe {
+            n = duxrt_achan_cap(this._ch)
+        }
+        return n
+    }
+
+    bool is_closed() {
+        int r = 0
+        unsafe {
+            r = duxrt_achan_is_closed(this._ch)
+        }
+        return r != 0
+    }
+
+    void close() {
+        this._closed = true
+        unsafe {
+            duxrt_achan_close(this._ch)
+        }
+    }
+
+    ~AsyncChan() {
+        if !this._closed {
+            this.close()
+        }
+        unsafe {
+            duxrt_achan_free(this._ch)
+        }
+    }
+}

--- a/stdlib/async/task.dux
+++ b/stdlib/async/task.dux
@@ -1,0 +1,52 @@
+# async.task — cooperative task scheduler (Phase 1)
+#
+# Phase 1 provides time-based cooperative yield and event-loop control.
+# Phase 2 will add async/await keywords with LLVM coroutine lowering.
+#
+# Usage: import async.task
+
+namespace task {
+    extern "C" void duxrt_async_sleep_ms(long ms) ;
+    extern "C" void duxrt_async_yield() ;
+    extern "C" void duxrt_async_run() ;
+    extern "C" void duxrt_async_stop() ;
+    extern "C" int  duxrt_async_is_running() ;
+
+    # Yield control for ms milliseconds (cooperative sleep).
+    void sleep_ms(long ms) {
+        unsafe {
+            duxrt_async_sleep_ms(ms)
+        }
+    }
+
+    # Cooperative yield — give other threads / tasks a chance to run.
+    void yield_now() {
+        unsafe {
+            duxrt_async_yield()
+        }
+    }
+
+    # Run the event loop until stop() is called.
+    # If stop() was called before run(), returns immediately.
+    void run() {
+        unsafe {
+            duxrt_async_run()
+        }
+    }
+
+    # Signal the event loop to stop.
+    void stop() {
+        unsafe {
+            duxrt_async_stop()
+        }
+    }
+
+    # Returns true while the event loop is executing inside run().
+    bool is_running() {
+        int r = 0
+        unsafe {
+            r = duxrt_async_is_running()
+        }
+        return r != 0
+    }
+}

--- a/tests/run_ok/stdlib_async_chan.dux
+++ b/tests/run_ok/stdlib_async_chan.dux
@@ -1,0 +1,67 @@
+import async.chan
+
+int main() {
+    AsyncChan ch = new AsyncChan(4)
+
+    # Starts empty and open
+    long n0 = ch.pending()
+    if n0 == 0 {
+        print("empty ok")
+    }
+    if !ch.is_closed() {
+        print("open ok")
+    }
+
+    # capacity reflects the constructor argument
+    long c = ch.capacity()
+    if c == 4 {
+        print("cap ok")
+    }
+
+    # try_recv on empty returns null
+    ptr r0 = ch.try_recv()
+    if r0 == null {
+        print("recv_empty ok")
+    }
+
+    # try_send returns true while there is space
+    bool s1 = ch.try_send(null)
+    if s1 {
+        print("send1 ok")
+    }
+    bool s2 = ch.try_send(null)
+    if s2 {
+        print("send2 ok")
+    }
+    long n1 = ch.pending()
+    if n1 == 2 {
+        print("pending2 ok")
+    }
+
+    # drain with try_recv
+    ptr d1 = ch.try_recv()
+    ptr d2 = ch.try_recv()
+    long n2 = ch.pending()
+    if n2 == 0 {
+        print("drained ok")
+    }
+
+    # fill to capacity — 5th send into a cap-4 buffer should fail
+    ch.try_send(null)
+    ch.try_send(null)
+    ch.try_send(null)
+    ch.try_send(null)
+    bool over = ch.try_send(null)
+    if !over {
+        print("full ok")
+    }
+
+    # close
+    ch.close()
+    if ch.is_closed() {
+        print("closed ok")
+    }
+
+    print("chan ok")
+    return 0
+}

--- a/tests/run_ok/stdlib_async_chan.expected
+++ b/tests/run_ok/stdlib_async_chan.expected
@@ -1,0 +1,11 @@
+empty ok
+open ok
+cap ok
+recv_empty ok
+send1 ok
+send2 ok
+pending2 ok
+drained ok
+full ok
+closed ok
+chan ok

--- a/tests/run_ok/stdlib_async_task.dux
+++ b/tests/run_ok/stdlib_async_task.dux
@@ -1,0 +1,24 @@
+import async.task
+
+int main() {
+    # sleep_ms should not crash
+    task.sleep_ms(1)
+    print("sleep ok")
+
+    # yield_now should not crash
+    task.yield_now()
+    print("yield ok")
+
+    # is_running returns false before run() is called
+    if !task.is_running() {
+        print("not_running ok")
+    }
+
+    # stop() before run() causes run() to return immediately
+    task.stop()
+    task.run()
+    print("run_stop ok")
+
+    print("task ok")
+    return 0
+}

--- a/tests/run_ok/stdlib_async_task.expected
+++ b/tests/run_ok/stdlib_async_task.expected
@@ -1,0 +1,5 @@
+sleep ok
+yield ok
+not_running ok
+run_stop ok
+task ok


### PR DESCRIPTION
- src/runtime/async_rt.c: event-loop control (run/stop) + cooperative sleep_ms/yield_now backed by nanosleep/sched_yield; stop flag handled atomically so stop()→run() exits immediately without spinning.

- src/runtime/achan_rt.c: fixed-capacity ring-buffer async channels. try_send/try_recv are non-blocking; send/recv block on condvars. Distinct from thread.chan (duxrt_chan_*) which is an unbounded/blocking FIFO — achan enforces a hard capacity ceiling.

- src/runtime/duxrt.h: duxrt_async_* and duxrt_achan_* declarations.

- CMakeLists.txt: async_rt.c and achan_rt.c added to duxrt library.

- stdlib/async/task.dux: namespace task { sleep_ms, yield_now, run, stop, is_running }.

- stdlib/async/chan.dux: AsyncChan class wrapping duxrt_achan_* with try_send, try_recv, send, recv, pending, capacity, is_closed, close.

- tests: stdlib_async_task and stdlib_async_chan — 163/163 passing.