### PR TITLE
feat(lang): async/await keywords with thread-backed futures (#110)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(duxrt STATIC
     src/runtime/net_http.c
     src/runtime/async_rt.c
     src/runtime/achan_rt.c
+    src/runtime/future_rt.c
 )
 
 target_include_directories(duxrt PUBLIC src/runtime)

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -22,6 +22,7 @@ void NewExpr::accept(Visitor& v)       const { v.visit(*this); }
 void ListExpr::accept(Visitor& v)      const { v.visit(*this); }
 void DictExpr::accept(Visitor& v)      const { v.visit(*this); }
 void LambdaExpr::accept(Visitor& v)    const { v.visit(*this); }
+void AwaitExpr::accept(Visitor& v)     const { v.visit(*this); }
 
 void BlockStmt::accept(Visitor& v)     const { v.visit(*this); }
 void ExprStmt::accept(Visitor& v)      const { v.visit(*this); }

--- a/src/ast/ast.hpp
+++ b/src/ast/ast.hpp
@@ -318,6 +318,12 @@ struct LambdaExpr final : Expr {
     void accept(Visitor& v) const override;
 };
 
+// AwaitExpr — "await <expr>" — waits for an async function call to complete.
+struct AwaitExpr final : Expr {
+    ExprPtr operand;
+    void accept(Visitor& v) const override;
+};
+
 struct Decorator {
     std::string name;   // "doc" or "doc::markdown"
     ExprList    args;
@@ -347,6 +353,7 @@ struct FunctionDecl final : Decl {
     bool                       is_ctor{false};
     bool                       is_dtor{false};
     bool                       is_static{false};
+    bool                       is_async{false};
     std::vector<InitEntry>     init_list;
     void accept(Visitor& v) const override;
 };
@@ -457,6 +464,7 @@ struct Visitor {
     virtual void visit(const ListExpr&)      = 0;
     virtual void visit(const DictExpr&)      = 0;
     virtual void visit(const LambdaExpr&)    = 0;
+    virtual void visit(const AwaitExpr&)     = 0;
 
     virtual void visit(const BlockStmt&)     = 0;
     virtual void visit(const ExprStmt&)      = 0;

--- a/src/ast/printer.hpp
+++ b/src/ast/printer.hpp
@@ -116,6 +116,11 @@ private:
         if (n.body) n.body->accept(*this);
     }
 
+    void visit(const AwaitExpr& n) override {
+        out_ << "await ";
+        if (n.operand) n.operand->accept(*this);
+    }
+
     // ── Statements ───────────────────────────────────────────────────────────
     void visit(const BlockStmt& n) override {
         out_ << pad() << "{\n";

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -290,14 +290,23 @@ std::string Codegen::mangle(const std::string& cls, const std::string& method) {
 
 Function* Codegen::declare_function(const ast::FunctionDecl& f,
                                     const std::string& mangled) {
+    // Return the existing declaration if already in module.
+    if (Function* existing = mod_->getFunction(mangled)) return existing;
+
     // Build LLVM function type
     std::vector<llvm::Type*> param_types;
     for (const auto& p : f.params)
         param_types.push_back(lower_type_expr(p.type));
 
-    TypeId ret_tid = types_.from_type_expr(f.return_type);
-    llvm::Type* ret_type = lower_type(ret_tid == TR::TID_UNKNOWN
-                                     ? TR::TID_VOID : ret_tid);
+    // Async launchers always return ptr (a DuxFuture*); the declared Dux
+    // return type is the value eventually obtained via 'await'.
+    llvm::Type* ret_type;
+    if (f.is_async) {
+        ret_type = ptr_type();
+    } else {
+        TypeId ret_tid = types_.from_type_expr(f.return_type);
+        ret_type = lower_type(ret_tid == TR::TID_UNKNOWN ? TR::TID_VOID : ret_tid);
+    }
 
     auto* ft = llvm::FunctionType::get(ret_type, param_types, false);
     auto* fn = Function::Create(ft, Function::ExternalLinkage, mangled, *mod_);
@@ -419,6 +428,12 @@ void Codegen::gen_func(const ast::FunctionDecl& f, const std::string& mangled,
     if (!f.body) return;
     if (f.modifier && (*f.modifier == "get" || *f.modifier == "set")) {
         // get/set modifiers compile as regular methods
+    }
+
+    // Async functions get their own three-function lowering.
+    if (f.is_async) {
+        gen_async_func(f, mangled);
+        return;
     }
 
     Function* fn = mod_->getFunction(mangled);
@@ -1580,6 +1595,40 @@ void Codegen::gen_try_catch(const ast::TryCatchStmt& s) {
 }
 
 void Codegen::gen_return(const ast::ReturnStmt& s) {
+    // ── Async body return: store result in future, then ret void ────────────
+    if (current_async_future_) {
+        Value* val = nullptr;
+        if (s.value) {
+            val = gen_expr(**s.value);
+            TypeId val_tid = type_id_of(**s.value);
+            val = coerce(val, val_tid, current_ret_type_);
+            if (current_ret_type_ == TR::TID_STR)
+                val = maybe_retain_str(val);
+        }
+        // Box result as void* for the future
+        Value* boxed;
+        if (val && val->getType()->isPointerTy()) {
+            boxed = val;
+        } else if (val && val->getType()->isIntegerTy()) {
+            Value* ext = builder_->CreateZExt(val, llvm::Type::getInt64Ty(*ctx_));
+            boxed = builder_->CreateIntToPtr(ext, ptr_type());
+        } else if (val && val->getType()->isFloatingPointTy()) {
+            Value* bits = builder_->CreateBitCast(val, llvm::Type::getInt64Ty(*ctx_));
+            boxed = builder_->CreateIntToPtr(bits, ptr_type());
+        } else {
+            boxed = llvm::ConstantPointerNull::get(
+                llvm::cast<llvm::PointerType>(ptr_type()));
+        }
+        Function* set_fn = get_or_declare_rt("duxrt_future_set",
+            llvm::Type::getVoidTy(*ctx_), {ptr_type(), ptr_type()});
+        builder_->CreateCall(set_fn, {current_async_future_, boxed});
+        emit_all_scope_cleanups();
+        emit_all_str_releases();
+        builder_->CreateRetVoid();
+        return;
+    }
+
+    // ── Normal return ────────────────────────────────────────────────────────
     Value* val = nullptr;
     if (s.value) {
         val = gen_expr(**s.value);
@@ -1816,6 +1865,7 @@ Value* Codegen::gen_expr(const ast::Expr& e) {
     if (auto* p = dynamic_cast<const ast::ListExpr*>(&e))    return gen_list(*p);
     if (auto* p = dynamic_cast<const ast::DictExpr*>(&e))    return gen_dict(*p);
     if (auto* lam = dynamic_cast<const ast::LambdaExpr*>(&e)) return gen_lambda(*lam);
+    if (auto* aw  = dynamic_cast<const ast::AwaitExpr*>(&e))  return gen_await(*aw);
 
     return llvm::ConstantPointerNull::get(
         llvm::cast<llvm::PointerType>(ptr_type()));
@@ -2623,6 +2673,305 @@ Value* Codegen::gen_lambda(const ast::LambdaExpr& e) {
     }
 
     return raw;
+}
+
+// ─── Await expression ─────────────────────────────────────────────────────────
+
+Value* Codegen::gen_await(const ast::AwaitExpr& e) {
+    // Generate the operand, which must resolve to a DuxFuture* (ptr).
+    // Async launchers always return ptr, so gen_call / gen_expr produces ptr.
+    Value* fut = gen_expr(*e.operand);
+
+    // Call duxrt_future_await(fut) → void* (the result boxed as ptr)
+    Function* await_fn = get_or_declare_rt("duxrt_future_await",
+        ptr_type(), {ptr_type()});
+    Value* raw = emit_call(await_fn, {fut});
+
+    // Free the future now that we've consumed it
+    Function* free_fn = get_or_declare_rt("duxrt_future_free",
+        llvm::Type::getVoidTy(*ctx_), {ptr_type()});
+    emit_call(free_fn, {fut});
+
+    // Unbox the raw result to the declared return type of the async function.
+    TypeId expected = e.type_id;
+    if (expected <= 0 || expected == TR::TID_VOID || expected == TR::TID_OBJECT)
+        return raw;   // void or ptr-compatible — already the right type
+    if (expected == TR::TID_STR)
+        return raw;   // DuxStr* stored directly as ptr
+    if (expected == TR::TID_INT) {
+        Value* i64 = builder_->CreatePtrToInt(raw, llvm::Type::getInt64Ty(*ctx_));
+        return builder_->CreateTrunc(i64, llvm::Type::getInt32Ty(*ctx_));
+    }
+    if (expected == TR::TID_LONG)
+        return builder_->CreatePtrToInt(raw, llvm::Type::getInt64Ty(*ctx_));
+    if (expected == TR::TID_BOOL) {
+        Value* i64 = builder_->CreatePtrToInt(raw, llvm::Type::getInt64Ty(*ctx_));
+        return builder_->CreateTrunc(i64, llvm::Type::getInt1Ty(*ctx_));
+    }
+    if (expected == TR::TID_DOUBLE) {
+        Value* i64  = builder_->CreatePtrToInt(raw, llvm::Type::getInt64Ty(*ctx_));
+        return builder_->CreateBitCast(i64, llvm::Type::getDoubleTy(*ctx_));
+    }
+    // Class / list / dict — all stored as ptr
+    return raw;
+}
+
+// ─── Async function codegen ───────────────────────────────────────────────────
+//
+// Given: async T f(T1 p1, ..., TN pN) { body }
+//
+// Emits three LLVM functions:
+//
+// 1. __async_body_{seq}(ptr __fut, T1 p1, ...) -> void
+//    Executes the original body.  'return val' calls duxrt_future_set and
+//    returns void (handled by the modified gen_return via current_async_future_).
+//
+// 2. __async_thunk_{seq}(ptr raw) -> ptr   [pthread-compatible]
+//    Unpacks the env array, calls the body, frees the env, returns null.
+//
+// 3. {mangled}(T1 p1, ..., TN pN) -> ptr   [the public launcher]
+//    Creates a DuxFuture*, allocates an env array, fills it, spawns the
+//    detached thread via duxrt_future_spawn_detached, and returns the future.
+
+void Codegen::gen_async_func(const ast::FunctionDecl& f, const std::string& mangled) {
+    if (!f.body) return;
+
+    int seq = async_counter_++;
+    std::string body_name  = "__async_body_"  + std::to_string(seq);
+    std::string thunk_name = "__async_thunk_" + std::to_string(seq);
+
+    // Original param LLVM types
+    std::vector<llvm::Type*> orig_param_types;
+    for (const auto& p : f.params)
+        orig_param_types.push_back(lower_type_expr(p.type));
+
+    TypeId      declared_ret_tid = types_.from_type_expr(f.return_type);
+
+    // ── 1. Body function: void __async_body_{seq}(ptr __fut, p1, ...) ───────
+    {
+        std::vector<llvm::Type*> body_params;
+        body_params.push_back(ptr_type()); // __fut
+        for (auto* t : orig_param_types) body_params.push_back(t);
+
+        auto* body_fty = llvm::FunctionType::get(
+            llvm::Type::getVoidTy(*ctx_), body_params, false);
+        auto* body_fn = Function::Create(body_fty, Function::InternalLinkage,
+                                         body_name, *mod_);
+
+        // Set personality function for EH
+        if (!body_fn->hasPersonalityFn()) {
+            auto* pft = llvm::FunctionType::get(llvm::Type::getInt32Ty(*ctx_), true);
+            auto* pf  = llvm::cast<llvm::Constant>(
+                mod_->getOrInsertFunction("__gxx_personality_v0", pft).getCallee());
+            body_fn->setPersonalityFn(pf);
+        }
+
+        // Save outer codegen state (same pattern as gen_lambda)
+        auto* outer_bb      = builder_->GetInsertBlock();
+        auto  outer_env     = env_;
+        auto  outer_str     = str_scopes_;
+        auto  outer_cleanup = cleanup_scopes_;
+        auto  outer_vcls    = var_class_;
+        auto  outer_fn_var  = fn_var_types_;
+        std::string outer_class     = current_class_;
+        TypeId      outer_ret       = current_ret_type_;
+        auto        outer_lp        = lp_stack_;
+        llvm::Function* outer_fn    = current_fn_;
+        llvm::Value*    outer_afut  = current_async_future_;
+
+        // Set up body state
+        current_fn_           = body_fn;
+        current_ret_type_     = declared_ret_tid;
+        current_class_        = "";
+        lp_stack_.clear();
+        env_.clear(); str_scopes_.clear(); cleanup_scopes_.clear();
+        var_class_.clear(); fn_var_types_.clear();
+
+        auto* body_entry = BasicBlock::Create(*ctx_, "entry", body_fn);
+        builder_->SetInsertPoint(body_entry);
+        env_push();
+
+        auto arg_it = body_fn->arg_begin();
+        // Bind __fut
+        Value* fut_alloca = make_alloca(ptr_type(), "__fut.addr");
+        builder_->CreateStore(&*arg_it, fut_alloca);
+        current_async_future_ = builder_->CreateLoad(ptr_type(), fut_alloca, "__fut");
+        ++arg_it;
+
+        // Bind params
+        for (const auto& p : f.params) {
+            llvm::Type* pt = lower_type_expr(p.type);
+            Value* alloca  = make_alloca(pt, p.name);
+            builder_->CreateStore(&*arg_it, alloca);
+            env_define(p.name, alloca);
+            ++arg_it;
+        }
+
+        for (const auto& p : f.params)
+            if (p.type.name == "__fn") fn_var_types_[p.name] = p.type;
+
+        // Generate the body
+        gen_stmts(f.body->body);
+
+        // Fallthrough: signal future with null and return void
+        if (!builder_->GetInsertBlock()->getTerminator()) {
+            // Signal future (void return or missing return)
+            Function* set_fn = get_or_declare_rt("duxrt_future_set",
+                llvm::Type::getVoidTy(*ctx_), {ptr_type(), ptr_type()});
+            Value* null_val = llvm::ConstantPointerNull::get(
+                llvm::cast<llvm::PointerType>(ptr_type()));
+            builder_->CreateCall(set_fn, {current_async_future_, null_val});
+            emit_all_scope_cleanups();
+            emit_all_str_releases();
+            builder_->CreateRetVoid();
+        }
+
+        // Pop scope stacks
+        if (!cleanup_scopes_.empty()) cleanup_scopes_.pop_back();
+        if (!str_scopes_.empty())     str_scopes_.pop_back();
+        if (!env_.empty())            env_.pop_back();
+
+        // Restore outer state
+        builder_->SetInsertPoint(outer_bb);
+        env_            = std::move(outer_env);
+        str_scopes_     = std::move(outer_str);
+        cleanup_scopes_ = std::move(outer_cleanup);
+        var_class_      = std::move(outer_vcls);
+        fn_var_types_   = std::move(outer_fn_var);
+        current_class_        = outer_class;
+        current_ret_type_     = outer_ret;
+        lp_stack_             = std::move(outer_lp);
+        current_fn_           = outer_fn;
+        current_async_future_ = outer_afut;
+    }
+
+    // ── 2. Thunk: ptr __async_thunk_{seq}(ptr raw) -> ptr ───────────────────
+    //
+    // env layout (array of ptr-sized slots):
+    //   [0]  = DuxFuture* (future)
+    //   [1+] = original params (coerced to ptr via inttoptr if needed)
+    {
+        Function* body_fn = mod_->getFunction(body_name);
+        auto* thunk_fty = llvm::FunctionType::get(ptr_type(), {ptr_type()}, false);
+        auto* thunk_fn  = Function::Create(thunk_fty, Function::InternalLinkage,
+                                            thunk_name, *mod_);
+        auto* thunk_entry = BasicBlock::Create(*ctx_, "entry", thunk_fn);
+        builder_->SetInsertPoint(thunk_entry);
+
+        Value* raw = &*thunk_fn->arg_begin();
+        raw->setName("env");
+
+        // Load future (slot 0)
+        Value* fut_slot = builder_->CreateConstGEP1_64(ptr_type(), raw, 0, "fut.slot");
+        Value* fut_val  = builder_->CreateLoad(ptr_type(), fut_slot, "fut");
+
+        // Load params (slots 1..N)
+        std::vector<Value*> body_args;
+        body_args.push_back(fut_val);
+        for (std::size_t i = 0; i < f.params.size(); ++i) {
+            Value* slot = builder_->CreateConstGEP1_64(ptr_type(), raw,
+                          (int64_t)(i + 1), f.params[i].name + ".slot");
+            Value* as_ptr = builder_->CreateLoad(ptr_type(), slot,
+                            f.params[i].name + ".raw");
+            // Unbox if the original param type is not a pointer
+            llvm::Type* orig_t = orig_param_types[i];
+            Value* unboxed;
+            if (orig_t->isPointerTy()) {
+                unboxed = as_ptr;
+            } else if (orig_t->isIntegerTy()) {
+                Value* i64 = builder_->CreatePtrToInt(as_ptr, llvm::Type::getInt64Ty(*ctx_));
+                unboxed = builder_->CreateTrunc(i64, orig_t);
+            } else if (orig_t->isDoubleTy()) {
+                Value* i64 = builder_->CreatePtrToInt(as_ptr, llvm::Type::getInt64Ty(*ctx_));
+                unboxed = builder_->CreateBitCast(i64, orig_t);
+            } else {
+                unboxed = as_ptr;
+            }
+            body_args.push_back(unboxed);
+        }
+
+        // Call the body
+        if (body_fn)
+            builder_->CreateCall(body_fn, body_args);
+
+        // Free the env array
+        Function* free_rt = get_or_declare_rt("free",
+            llvm::Type::getVoidTy(*ctx_), {ptr_type()});
+        builder_->CreateCall(free_rt, {raw});
+
+        builder_->CreateRet(llvm::ConstantPointerNull::get(
+            llvm::cast<llvm::PointerType>(ptr_type())));
+
+        // Restore insert point to original (thunk is fully generated inline)
+        // Nothing to restore — we don't save/restore outer BB for the thunk
+        // because we haven't moved to a new BB in the outer function yet.
+        // Actually the thunk is a separate function; the outer builder_ context
+        // is fine since we re-set it after the body function above.
+    }
+
+    // ── 3. Launcher: ptr {mangled}(original_params...) -> ptr ───────────────
+    {
+        Function* launcher = mod_->getFunction(mangled);
+        if (!launcher) {
+            // Forward-declaration was not done (e.g. class method) — create it now
+            std::vector<llvm::Type*> p_types;
+            if (!current_class_.empty()) p_types.push_back(ptr_type()); // this
+            for (auto* t : orig_param_types) p_types.push_back(t);
+            auto* fty = llvm::FunctionType::get(ptr_type(), p_types, false);
+            launcher  = Function::Create(fty, Function::ExternalLinkage, mangled, *mod_);
+        }
+        if (!launcher->empty()) return; // already generated
+
+        auto* entry = BasicBlock::Create(*ctx_, "entry", launcher);
+        builder_->SetInsertPoint(entry);
+
+        // Create a DuxFuture*
+        Function* future_new = get_or_declare_rt("duxrt_future_new",
+            ptr_type(), {});
+        Value* fut = builder_->CreateCall(future_new, {}, "fut");
+
+        // Allocate env array: (N+1) slots × 8 bytes each
+        std::size_t n_slots = f.params.size() + 1;
+        Value* sz = llvm::ConstantInt::get(llvm::Type::getInt64Ty(*ctx_),
+                                            (int64_t)(n_slots * 8));
+        Value* env = rt_malloc(sz);
+
+        // Store future at slot 0
+        Value* fut_slot = builder_->CreateConstGEP1_64(ptr_type(), env, 0, "fut.env.slot");
+        builder_->CreateStore(fut, fut_slot);
+
+        // Store each param at slots 1..N
+        auto arg_it = launcher->arg_begin();
+        for (std::size_t i = 0; i < f.params.size(); ++i) {
+            Value* arg    = &*arg_it++;
+            Value* slot   = builder_->CreateConstGEP1_64(ptr_type(), env,
+                            (int64_t)(i + 1), f.params[i].name + ".env.slot");
+            // Box if not already a pointer
+            Value* boxed;
+            if (arg->getType()->isPointerTy()) {
+                boxed = arg;
+            } else if (arg->getType()->isIntegerTy()) {
+                Value* ext = builder_->CreateZExt(arg, llvm::Type::getInt64Ty(*ctx_));
+                boxed = builder_->CreateIntToPtr(ext, ptr_type());
+            } else if (arg->getType()->isDoubleTy()) {
+                Value* bits = builder_->CreateBitCast(arg, llvm::Type::getInt64Ty(*ctx_));
+                boxed = builder_->CreateIntToPtr(bits, ptr_type());
+            } else {
+                boxed = llvm::ConstantPointerNull::get(
+                    llvm::cast<llvm::PointerType>(ptr_type()));
+            }
+            builder_->CreateStore(boxed, slot);
+        }
+
+        // Spawn detached thread
+        Function* thunk_fn = mod_->getFunction(thunk_name);
+        Function* spawn_fn = get_or_declare_rt("duxrt_future_spawn_detached",
+            llvm::Type::getVoidTy(*ctx_), {ptr_type(), ptr_type()});
+        builder_->CreateCall(spawn_fn, {thunk_fn, env});
+
+        // Return the future
+        builder_->CreateRet(fut);
+    }
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/src/codegen/codegen.hpp
+++ b/src/codegen/codegen.hpp
@@ -179,7 +179,13 @@ private:
     std::string     current_namespace_;  // set while generating a namespace body
     std::string     pending_label_;   // label from &label before a loop stmt
     int             lambda_counter_{0};  // counter for unique lambda names
+    int             async_counter_{0};   // counter for unique async body/thunk names
     std::unordered_map<std::string, ast::TypeExpr> fn_var_types_; // fn-typed vars/params
+
+    // Async codegen state:
+    // Non-null while generating an async body function; holds the LLVM Value
+    // for the DuxFuture* first parameter so gen_return can route through it.
+    llvm::Value*    current_async_future_{nullptr};
 
     // ── Type lowering (#14) ──────────────────────────────────────────────
     llvm::Type* lower_type(TypeId tid);
@@ -260,6 +266,10 @@ private:
     llvm::Value* gen_list(const ast::ListExpr& e);
     llvm::Value* gen_dict(const ast::DictExpr& e);
     llvm::Value* gen_lambda(const ast::LambdaExpr& e);
+    llvm::Value* gen_await(const ast::AwaitExpr& e);
+
+    // Async helpers
+    void         gen_async_func(const ast::FunctionDecl& f, const std::string& mangled);
 
     // ── Helpers ──────────────────────────────────────────────────────────
     llvm::Value* load_var(const std::string& name, const ast::SourceLoc& loc);

--- a/src/lexer/dux.l
+++ b/src/lexer/dux.l
@@ -131,6 +131,8 @@ ALNUM   [a-zA-Z0-9_]
 "throw"      { need_semi = false; return yy::parser::make_KW_THROW(loc);     }
 "unsafe"     { need_semi = false; return yy::parser::make_KW_UNSAFE(loc);    }
 "extern"     { need_semi = false; return yy::parser::make_KW_EXTERN(loc);    }
+"async"      { need_semi = false; return yy::parser::make_KW_ASYNC(loc);     }
+"await"      { need_semi = true;  return yy::parser::make_KW_AWAIT(loc);     }
 "and"        { need_semi = false; return yy::parser::make_KW_AND(loc);       }
 "or"         { need_semi = false; return yy::parser::make_KW_OR(loc);        }
 "not"        { need_semi = false; return yy::parser::make_KW_NOT(loc);       }

--- a/src/parser/dux.y
+++ b/src/parser/dux.y
@@ -90,6 +90,7 @@ static std::unique_ptr<T> mk(Args&&... a) {
 %token KW_AUTO "auto"
 %token KW_AND KW_OR KW_NOT
 %token KW_UNSAFE KW_EXTERN
+%token KW_ASYNC KW_AWAIT
 
 /* Type keywords */
 %token KW_VOID KW_INT KW_LONG KW_REAL KW_DOUBLE KW_STR
@@ -276,7 +277,9 @@ dotted_name
     | KW_STR                    { $$ = "str"; }
     | KW_LIST                   { $$ = "list"; }
     | KW_DICT                   { $$ = "dict"; }
+    | KW_ASYNC                  { $$ = "async"; }
     | dotted_name DOT IDENT     { $$ = $1 + '.' + $3; }
+    | dotted_name DOT KW_ASYNC  { $$ = $1 + ".async"; }
     ;
 
 /* =====================================================================
@@ -563,6 +566,21 @@ func_decl
             f->params       = std::move($5);
             f->modifier     = $7;
             f->body         = std::move(*$8);
+            $$ = std::move(f);
+        }
+    | KW_ASYNC type_expr IDENT opt_type_params LPAREN param_list RPAREN block
+        {
+            auto f          = mk<FunctionDecl>();
+            f->loc          = sl(@$, driver);
+            f->return_type  = $2;
+            f->name         = $3;
+            for (const auto& [pname, bname] : $4) {
+                f->type_params.push_back(pname);
+                if (!bname.empty()) f->type_bounds.push_back(TypeBound{pname, bname});
+            }
+            f->params       = std::move($6);
+            f->body         = std::move(*$8);
+            f->is_async     = true;
             $$ = std::move(f);
         }
     | KW_STATIC type_expr IDENT LPAREN param_list RPAREN opt_func_modifier block
@@ -1238,6 +1256,13 @@ unary_expr
     | PLUSPLUS   unary_expr  { auto e = mk<UnaryExpr>(); e->loc = sl(@$, driver); e->op = "++"; e->prefix = true; e->operand = std::move($2); $$ = std::move(e); }
     | MINUSMINUS unary_expr  { auto e = mk<UnaryExpr>(); e->loc = sl(@$, driver); e->op = "--"; e->prefix = true; e->operand = std::move($2); $$ = std::move(e); }
     | KW_NOT     unary_expr  { auto e = mk<UnaryExpr>(); e->loc = sl(@$, driver); e->op = "!"; e->prefix = true; e->operand = std::move($2); $$ = std::move(e); }
+    | KW_AWAIT   unary_expr
+        {
+            auto e = mk<AwaitExpr>();
+            e->loc = sl(@$, driver);
+            e->operand = std::move($2);
+            $$ = std::move(e);
+        }
     | postfix_expr  { $$ = std::move($1); }
     ;
 

--- a/src/runtime/duxrt.h
+++ b/src/runtime/duxrt.h
@@ -479,6 +479,13 @@ void    duxrt_http_req_free(void* req);
 DuxStr* duxrt_http_format_response(int32_t status, DuxStr* status_text,
                                     void* headers_dict, DuxStr* body);
 
+/* ── Future (async/await Phase 2) ───────────────────────────────────────── */
+void*   duxrt_future_new(void);
+void    duxrt_future_free(void* fut);
+void    duxrt_future_set(void* fut, void* result);
+void*   duxrt_future_await(void* fut);
+void    duxrt_future_spawn_detached(void* fn, void* env);
+
 /* ── Async scheduler (Phase 1) ───────────────────────────────────────────── */
 void    duxrt_async_sleep_ms(int64_t ms);
 void    duxrt_async_yield(void);

--- a/src/runtime/future_rt.c
+++ b/src/runtime/future_rt.c
@@ -1,0 +1,85 @@
+/*
+ * future_rt.c — DuxFuture: thread-backed async/await primitive
+ *
+ * A DuxFuture represents a value that will be produced by a detached thread.
+ * The caller can block on duxrt_future_await() to retrieve the result.
+ *
+ * Lifecycle:
+ *   1. Launcher creates a future with duxrt_future_new().
+ *   2. Launcher spawns a detached thread (via duxrt_future_spawn_detached).
+ *   3. Worker thread calls duxrt_future_set() when done.
+ *   4. Awaiter calls duxrt_future_await() — blocks until step 3.
+ *   5. Awaiter frees the future with duxrt_future_free().
+ */
+#include "duxrt.h"
+#include <pthread.h>
+#include <stdlib.h>
+
+typedef struct DuxFuture {
+    pthread_mutex_t mu;
+    pthread_cond_t  cond;
+    void*           result;
+    int             done;
+} DuxFuture;
+
+/* ── Lifecycle ───────────────────────────────────────────────────────────── */
+
+void* duxrt_future_new(void) {
+    DuxFuture* f = (DuxFuture*)calloc(1, sizeof(DuxFuture));
+    if (!f) return NULL;
+    pthread_mutex_init(&f->mu, NULL);
+    pthread_cond_init(&f->cond, NULL);
+    return f;
+}
+
+void duxrt_future_free(void* fut) {
+    DuxFuture* f = (DuxFuture*)fut;
+    if (!f) return;
+    pthread_mutex_destroy(&f->mu);
+    pthread_cond_destroy(&f->cond);
+    free(f);
+}
+
+/* ── Signal completion ───────────────────────────────────────────────────── */
+
+/* Called by the async worker thread when it has computed its result. */
+void duxrt_future_set(void* fut, void* result) {
+    DuxFuture* f = (DuxFuture*)fut;
+    if (!f) return;
+    pthread_mutex_lock(&f->mu);
+    f->result = result;
+    f->done   = 1;
+    pthread_cond_signal(&f->cond);
+    pthread_mutex_unlock(&f->mu);
+}
+
+/* ── Await ───────────────────────────────────────────────────────────────── */
+
+/* Block until the future is resolved; returns the result pointer. */
+void* duxrt_future_await(void* fut) {
+    DuxFuture* f = (DuxFuture*)fut;
+    if (!f) return NULL;
+    pthread_mutex_lock(&f->mu);
+    while (!f->done)
+        pthread_cond_wait(&f->cond, &f->mu);
+    void* r = f->result;
+    pthread_mutex_unlock(&f->mu);
+    return r;
+}
+
+/* ── Spawn ───────────────────────────────────────────────────────────────── */
+
+/*
+ * Spawn a detached thread that calls fn(env).
+ * fn must be a pthread-compatible worker: (void*) -> void*
+ * The thread is detached so no join is needed; completion is signalled via
+ * the future (duxrt_future_set).
+ */
+void duxrt_future_spawn_detached(void* fn, void* env) {
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    pthread_t tid;
+    pthread_create(&tid, &attr, (void*(*)(void*))fn, env);
+    pthread_attr_destroy(&attr);
+}

--- a/src/sema/sema.cpp
+++ b/src/sema/sema.cpp
@@ -132,6 +132,7 @@ void Sema::hoist_top(const ast::DeclList& decls) {
             s.kind        = SymKind::Function;
             s.type        = ret;
             s.return_type = ret;
+            s.is_async    = f->is_async;
             s.decl        = dp.get();
             s.loc         = f->loc;
             for (const auto& p : f->params)
@@ -740,6 +741,13 @@ TypeId Sema::check_expr(const ast::Expr& e) {
         result = check_dict(*dct_e);
     } else if (auto* lam = dynamic_cast<const ast::LambdaExpr*>(&e)) {
         result = check_lambda(*lam);
+    } else if (auto* aw = dynamic_cast<const ast::AwaitExpr*>(&e)) {
+        // await <expr> — evaluate the inner expression while marking that
+        // we are inside an await so async calls are permitted.
+        bool saved_in_await = in_await_;
+        in_await_ = true;
+        result = check_expr(*aw->operand);
+        in_await_ = saved_in_await;
     }
     // else: unknown Expr subtype — leave as TID_UNKNOWN
 
@@ -966,6 +974,10 @@ TypeId Sema::check_call(const ast::CallExpr& e) {
 
     // Check argument count
     if (sym->kind == SymKind::Function || sym->kind == SymKind::BuiltIn) {
+        // Async functions must be called with 'await'
+        if (sym->is_async && !in_await_) {
+            err(e.loc, "async function '" + sym->name + "' must be called with 'await'");
+        }
         if (!sym->params.empty() &&
             sym->params.size() != e.args.size()) {
             std::ostringstream os;

--- a/src/sema/sema.hpp
+++ b/src/sema/sema.hpp
@@ -26,6 +26,7 @@ private:
     TypeId      current_class_type_{TypeRegistry::TID_UNKNOWN};
     bool        in_loop_{false};
     bool        in_unsafe_{false};  // inside unsafe { } block — ptr casts allowed
+    bool        in_await_{false};   // inside an await expression — async calls allowed
     int         error_count_{0};
 
     // ── Hoisting (pass 1) ──────────────────────────────────────────────────

--- a/src/sema/symbol.hpp
+++ b/src/sema/symbol.hpp
@@ -21,6 +21,7 @@ struct Symbol {
     ast::Node*   decl{nullptr};  // non-owning back-pointer
     ast::SourceLoc loc;
     bool         is_const{false};
+    bool         is_async{false};  // function declared with 'async' modifier
 };
 
 class Scope {

--- a/tests/parse_ok/async_await.dux
+++ b/tests/parse_ok/async_await.dux
@@ -1,0 +1,14 @@
+# Parse-only test for async/await syntax
+async str fetch(str url) {
+    return "data"
+}
+
+async void fire() {
+    int x = 1
+}
+
+int main() {
+    str s = await fetch("http://example.com")
+    await fire()
+    return 0
+}

--- a/tests/run_ok/stdlib_async_await.dux
+++ b/tests/run_ok/stdlib_async_await.dux
@@ -1,0 +1,39 @@
+import async.task
+
+# Async function that returns a string
+async str make_greeting(str name) {
+    task.sleep_ms(1)
+    return "Hello, " + name
+}
+
+# Async function that returns an integer
+async int double_val(int x) {
+    task.sleep_ms(1)
+    return x + x
+}
+
+# Async void function (fire-and-forget, still awaitable for sync)
+async void do_work() {
+    task.sleep_ms(1)
+}
+
+int main() {
+    # Await a str-returning async function
+    str greeting = await make_greeting("World")
+    if greeting == "Hello, World" {
+        print("greeting ok")
+    }
+
+    # Await an int-returning async function
+    int result = await double_val(21)
+    if result == 42 {
+        print("double ok")
+    }
+
+    # Await a void async function
+    await do_work()
+    print("void ok")
+
+    print("async_await ok")
+    return 0
+}

--- a/tests/run_ok/stdlib_async_await.expected
+++ b/tests/run_ok/stdlib_async_await.expected
@@ -1,0 +1,4 @@
+greeting ok
+double ok
+void ok
+async_await ok


### PR DESCRIPTION
- Lexer: add 'async' and 'await' keywords (KW_ASYNC, KW_AWAIT)
- Parser: async func_decl, await unary_expr; extend dotted_name to
  allow KW_ASYNC so 'import async.task' keeps working
- AST: FunctionDecl.is_async flag; new AwaitExpr node + Visitor hook
- Printer: print 'await' in AwaitExpr
- Sema: hoist is_async; enforce await-gate on async call sites;
  in_await_ flag lets await expressions pass the gate
- Codegen: three-function lowering per async decl
    __async_body_N  – real body, sets future on return
    __async_thunk_N – pthread entry, unpacks env, calls body, frees env
    {mangled}       – launcher: alloc future + env, spawn detached, return future*
  gen_await: call launcher -> future*, await, free, unbox by TypeId
  gen_return: when inside async body, box result and call duxrt_future_set
- Runtime: new future_rt.c — DuxFuture (mutex+condvar), duxrt_future_new,
  duxrt_future_set, duxrt_future_await, duxrt_future_free,
  duxrt_future_spawn_detached; declarations added to duxrt.h
- Tests: parse_ok/async_await.dux, run_ok/stdlib_async_await.{dux,expected}
  All 165 tests pass

https://claude.ai/code/session_013268REeAo1j62C7yC5BB9P