### PR TITLE
feat(lang): enum payload variants — tagged-union semantics

### DIFF
--- a/src/ast/ast.hpp
+++ b/src/ast/ast.hpp
@@ -226,6 +226,7 @@ struct MatchPattern {
     Kind        kind{Kind::Wildcard};
     std::string enum_name;    // for EnumVariant: "Color"
     std::string variant_name; // for EnumVariant: "Red"
+    std::vector<std::string> bindings; // for EnumVariant payload: Result.Err(msg) => msg
     long long   int_value{0}; // for IntLit
     bool        bool_value{false}; // for BoolLit
     SourceLoc   loc;

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -185,9 +185,13 @@ llvm::Type* Codegen::lower_type(TypeId tid) {
         case TR::TID_OBJECT: return ptr_type();
         case TR::TID_NULL:   return ptr_type();
         default:
-            // User-defined types: enums are i32, classes are heap-allocated ptr
-            if (tid >= 0 && types_.info(tid).kind == sema::TypeKind::Enum)
-                return llvm::Type::getInt32Ty(*ctx_);
+            // User-defined types: payload enums are ptr; simple enums are i32; classes are ptr
+            if (tid >= 0 && types_.info(tid).kind == sema::TypeKind::Enum) {
+                const auto& ti = types_.info(tid);
+                bool has_payload = std::any_of(ti.variants.begin(), ti.variants.end(),
+                    [](const sema::EnumVariantInfo& v){ return !v.payload.empty(); });
+                return has_payload ? ptr_type() : llvm::Type::getInt32Ty(*ctx_);
+            }
             return ptr_type(); // user-defined class types are heap-allocated
     }
 }
@@ -220,6 +224,9 @@ void Codegen::build_enum_type(const ast::EnumDecl& e) {
         sema::EnumVariantInfo vi;
         vi.name = v.name;
         vi.tag  = tag++;
+        // Copy payload type info so codegen knows arity and types of each variant
+        for (const auto& pt : v.payload)
+            vi.payload.push_back(types_.from_type_expr(pt));
         ti.variants.push_back(vi);
     }
     enum_types_[e.name] = id;
@@ -1416,14 +1423,93 @@ void Codegen::gen_switch(const ast::SwitchStmt& s) {
     builder_->SetInsertPoint(exit_bb);
 }
 
+// ─── Enum payload helpers ─────────────────────────────────────────────────────
+
+int Codegen::enum_max_payload_arity(const sema::TypeInfo& ti) const {
+    int max_arity = 0;
+    for (const auto& v : ti.variants)
+        max_arity = std::max(max_arity, (int)v.payload.size());
+    return max_arity;
+}
+
+llvm::Value* Codegen::box_to_ptr(llvm::Value* v) {
+    if (v->getType()->isPointerTy()) return v;
+    if (v->getType()->isIntegerTy()) {
+        Value* ext = builder_->CreateZExt(v, llvm::Type::getInt64Ty(*ctx_));
+        return builder_->CreateIntToPtr(ext, ptr_type());
+    }
+    if (v->getType()->isDoubleTy()) {
+        Value* bits = builder_->CreateBitCast(v, llvm::Type::getInt64Ty(*ctx_));
+        return builder_->CreateIntToPtr(bits, ptr_type());
+    }
+    // Fallback
+    return llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptr_type()));
+}
+
+llvm::Value* Codegen::unbox_from_ptr(llvm::Value* v, llvm::Type* target) {
+    if (target->isPointerTy()) return v;
+    if (target->isIntegerTy()) {
+        Value* i64 = builder_->CreatePtrToInt(v, llvm::Type::getInt64Ty(*ctx_));
+        return builder_->CreateTrunc(i64, target);
+    }
+    if (target->isDoubleTy()) {
+        Value* i64 = builder_->CreatePtrToInt(v, llvm::Type::getInt64Ty(*ctx_));
+        return builder_->CreateBitCast(i64, target);
+    }
+    return v;
+}
+
+// Allocate and fill a payload enum heap struct:
+//   Layout: [ i32 tag | padding | ptr field_0 | ptr field_1 | ... ]
+//   Total:  (1 + max_arity) * 8 bytes  (tag occupies first 4 bytes, 4 bytes padding)
+llvm::Value* Codegen::gen_enum_ctor(const sema::TypeInfo& ti,
+                                     const sema::EnumVariantInfo& vi,
+                                     const std::vector<ast::ExprPtr>& args) {
+    int max_arity = enum_max_payload_arity(ti);
+    int n_slots   = 1 + max_arity; // slot 0 = tag (i32 in first 4 bytes), slots 1..N = payload ptrs
+    Value* sz  = llvm::ConstantInt::get(llvm::Type::getInt64Ty(*ctx_),
+                                         (int64_t)(n_slots * 8));
+    Value* mem = rt_malloc(sz);
+
+    // Store tag as i32 at byte offset 0
+    Value* tag_val = llvm::ConstantInt::get(llvm::Type::getInt32Ty(*ctx_),
+                                             static_cast<uint64_t>(vi.tag));
+    builder_->CreateStore(tag_val, mem);
+
+    // Store each payload field (boxed to ptr-sized slot) at ptr-slot offsets 1..N
+    for (int i = 0; i < (int)args.size() && i < (int)vi.payload.size(); ++i) {
+        Value* val    = gen_expr(*args[i]);
+        Value* boxed  = box_to_ptr(val);
+        Value* slot   = builder_->CreateConstGEP1_64(ptr_type(), mem,
+                                                      (int64_t)(i + 1),
+                                                      vi.name + ".field" + std::to_string(i));
+        builder_->CreateStore(boxed, slot);
+    }
+
+    return mem; // ptr to the heap struct
+}
+
 void Codegen::gen_match(const ast::MatchStmt& s) {
     Function* fn = builder_->GetInsertBlock()->getParent();
-    Value* match_val = gen_expr(*s.expr);
+    Value* match_raw = gen_expr(*s.expr);
 
-    // Ensure match value is an integer (enums are i32)
-    if (!match_val->getType()->isIntegerTy()) {
-        match_val = builder_->CreateFPToSI(match_val,
-                                           llvm::Type::getInt32Ty(*ctx_));
+    // Determine if this is a payload enum (ptr) or simple enum / integer (i32).
+    // For payload enums the heap struct starts with an i32 tag at byte offset 0.
+    Value*  match_ptr = nullptr; // non-null for payload enums
+    Value*  match_val = nullptr; // i32 discriminant for the switch
+
+    if (match_raw->getType()->isPointerTy()) {
+        // Payload enum: load i32 tag from offset 0 of the heap struct
+        match_ptr = match_raw;
+        match_val = builder_->CreateLoad(llvm::Type::getInt32Ty(*ctx_),
+                                          match_ptr, "enum.tag");
+    } else if (match_raw->getType()->isIntegerTy()) {
+        match_val = match_raw;
+        if (!match_val->getType()->isIntegerTy(32))
+            match_val = builder_->CreateTrunc(match_val, llvm::Type::getInt32Ty(*ctx_));
+    } else {
+        // Float or other — coerce to i32 (fallback, not normally reached for enums)
+        match_val = builder_->CreateFPToSI(match_raw, llvm::Type::getInt32Ty(*ctx_));
     }
 
     auto* exit_bb = BasicBlock::Create(*ctx_, "match.end", fn);
@@ -1482,6 +1568,40 @@ void Codegen::gen_match(const ast::MatchStmt& s) {
         sw->addCase(case_val, case_bb);
         builder_->SetInsertPoint(case_bb);
         env_push();
+
+        // Bind payload fields if this is a payload enum arm with bindings
+        if (match_ptr && !arm->pattern.bindings.empty()) {
+            // Find the variant info to get payload types
+            const sema::EnumVariantInfo* vi = nullptr;
+            auto it = enum_types_.find(arm->pattern.enum_name);
+            if (it != enum_types_.end()) {
+                const sema::TypeInfo& ti = types_.info(it->second);
+                for (const auto& v : ti.variants)
+                    if (v.name == arm->pattern.variant_name) { vi = &v; break; }
+            }
+
+            for (int i = 0; i < (int)arm->pattern.bindings.size(); ++i) {
+                const std::string& bname = arm->pattern.bindings[i];
+                // Load ptr from slot i+1
+                Value* slot = builder_->CreateConstGEP1_64(ptr_type(), match_ptr,
+                                                            (int64_t)(i + 1),
+                                                            bname + ".slot");
+                Value* field_ptr = builder_->CreateLoad(ptr_type(), slot, bname + ".raw");
+
+                // Determine target type for unboxing
+                llvm::Type* field_ty = ptr_type(); // default: ptr (str, object, etc.)
+                if (vi && i < (int)vi->payload.size()) {
+                    TypeId payload_tid = vi->payload[i];
+                    field_ty = lower_type(payload_tid);
+                }
+
+                Value* field_val  = unbox_from_ptr(field_ptr, field_ty);
+                Value* field_alloca = make_alloca(field_ty, bname);
+                builder_->CreateStore(field_val, field_alloca);
+                env_define(bname, field_alloca);
+            }
+        }
+
         gen_stmts(arm->body);
         env_pop();
         if (!builder_->GetInsertBlock()->getTerminator())
@@ -2219,6 +2339,23 @@ Value* Codegen::gen_call(const ast::CallExpr& e) {
                 }
                 return builder_->CreateCall(ns_fn, args);
             }
+
+            // Enum constructor: Result.Err("msg") — detected before class method lookup
+            if (auto* id2 = dynamic_cast<const ast::IdentExpr*>(mem->object.get())) {
+                auto enum_it = enum_types_.find(id2->name);
+                if (enum_it != enum_types_.end()) {
+                    TypeId enum_tid = enum_it->second;
+                    const sema::TypeInfo& ti = types_.info(enum_tid);
+                    bool is_payload_enum = std::any_of(ti.variants.begin(), ti.variants.end(),
+                        [](const sema::EnumVariantInfo& v){ return !v.payload.empty(); });
+                    if (is_payload_enum) {
+                        for (const auto& v : ti.variants) {
+                            if (v.name == mem->member)
+                                return gen_enum_ctor(ti, v, e.args);
+                        }
+                    }
+                }
+            }
         }
 
         Value* obj = gen_expr(*mem->object);
@@ -2267,20 +2404,52 @@ Value* Codegen::gen_call(const ast::CallExpr& e) {
 }
 
 Value* Codegen::gen_member(const ast::MemberExpr& e) {
-    // Enum variant access: Color.Red  →  i32 constant
+    // Enum variant access: Color.Red or Result.Ok (payload enum, no-payload variant)
     if (auto* id = dynamic_cast<const ast::IdentExpr*>(e.object.get())) {
         auto enum_it = enum_types_.find(id->name);
         if (enum_it != enum_types_.end()) {
             TypeId enum_tid = enum_it->second;
             const sema::TypeInfo& ti = types_.info(enum_tid);
+            bool is_payload_enum = std::any_of(ti.variants.begin(), ti.variants.end(),
+                [](const sema::EnumVariantInfo& v){ return !v.payload.empty(); });
+
             for (const auto& v : ti.variants) {
-                if (v.name == e.member)
-                    return llvm::ConstantInt::get(
-                        llvm::Type::getInt32Ty(*ctx_),
-                        static_cast<uint64_t>(v.tag));
+                if (v.name != e.member) continue;
+
+                if (!is_payload_enum) {
+                    // Simple enum: return bare i32 discriminant (original behaviour)
+                    return llvm::ConstantInt::get(llvm::Type::getInt32Ty(*ctx_),
+                                                   static_cast<uint64_t>(v.tag));
+                }
+
+                if (!v.payload.empty()) {
+                    // Payload variant accessed without args — should be constructed
+                    // via a CallExpr (gen_call intercepts it). Reaching here means
+                    // the variant was used as a bare value, which is unusual.
+                    // Return null ptr as a safe fallback.
+                    driver_.warning(e.loc, "payload variant '" + v.name +
+                                    "' used without constructor args; use " +
+                                    id->name + "." + v.name + "(value)");
+                    return llvm::ConstantPointerNull::get(
+                        llvm::cast<llvm::PointerType>(ptr_type()));
+                }
+
+                // No-payload variant in a payload enum: alloc heap struct with just the tag
+                int max_arity = enum_max_payload_arity(ti);
+                Value* sz  = llvm::ConstantInt::get(llvm::Type::getInt64Ty(*ctx_),
+                                                     (int64_t)((1 + max_arity) * 8));
+                Value* mem = rt_malloc(sz);
+                Value* tag_val = llvm::ConstantInt::get(llvm::Type::getInt32Ty(*ctx_),
+                                                         static_cast<uint64_t>(v.tag));
+                builder_->CreateStore(tag_val, mem);
+                return mem;
             }
+
             driver_.warning(e.loc, "unknown enum variant '" + e.member +
                             "' on '" + id->name + "'");
+            if (is_payload_enum)
+                return llvm::ConstantPointerNull::get(
+                    llvm::cast<llvm::PointerType>(ptr_type()));
             return llvm::ConstantInt::get(llvm::Type::getInt32Ty(*ctx_), 0);
         }
 

--- a/src/codegen/codegen.hpp
+++ b/src/codegen/codegen.hpp
@@ -327,6 +327,18 @@ private:
 
     TypeId type_id_of(const ast::Expr& e) const;
 
+    // Enum payload helpers
+    // Returns the max payload arity across all variants of the given enum TypeInfo.
+    int  enum_max_payload_arity(const sema::TypeInfo& ti) const;
+    // Generate a heap-allocated enum value: { i32 tag, ptr field... }
+    llvm::Value* gen_enum_ctor(const sema::TypeInfo& ti,
+                               const sema::EnumVariantInfo& vi,
+                               const std::vector<ast::ExprPtr>& args);
+    // Box a value to ptr-sized slot (same scheme as async env).
+    llvm::Value* box_to_ptr(llvm::Value* v);
+    // Unbox a ptr slot back to the given LLVM type.
+    llvm::Value* unbox_from_ptr(llvm::Value* v, llvm::Type* target);
+
     void err(const ast::SourceLoc& loc, const std::string& msg);
 };
 

--- a/src/parser/dux.y
+++ b/src/parser/dux.y
@@ -980,11 +980,21 @@ match_arm
 match_pattern
     : IDENT DOT IDENT
         {
-            /* EnumName.Variant */
+            /* EnumName.Variant  (no payload binding) */
             MatchPattern p; p.loc = sl(@$, driver);
             p.kind = MatchPattern::Kind::EnumVariant;
             p.enum_name    = $1;
             p.variant_name = $3;
+            $$ = std::move(p);
+        }
+    | IDENT DOT IDENT LPAREN ident_list RPAREN
+        {
+            /* EnumName.Variant(binding1, binding2, ...)  — payload destructure */
+            MatchPattern p; p.loc = sl(@$, driver);
+            p.kind = MatchPattern::Kind::EnumVariant;
+            p.enum_name    = $1;
+            p.variant_name = $3;
+            p.bindings     = std::move($5);
             $$ = std::move(p);
         }
     | INT_LIT
@@ -1010,13 +1020,13 @@ match_pattern
         }
     | IDENT
         {
-            /* bare identifier: "_" is wildcard, any other name is also wildcard for now
-               (binding variables deferred to a future milestone) */
+            /* bare identifier — wildcard */
             MatchPattern p; p.loc = sl(@$, driver);
             p.kind = MatchPattern::Kind::Wildcard;
             $$ = std::move(p);
         }
     ;
+
 
 /* -- Try / catch ------------------------------------------------------- */
 try_stmt

--- a/src/sema/sema.cpp
+++ b/src/sema/sema.cpp
@@ -598,8 +598,28 @@ void Sema::check_match(const ast::MatchStmt& s) {
                         "' has no variant '" + arm.pattern.variant_name + "'");
             }
         }
-        // Type-check the arm body
+        // Type-check the arm body, injecting any payload bindings into scope
         scopes_.push();
+        if (arm.pattern.kind == ast::MatchPattern::Kind::EnumVariant &&
+            !arm.pattern.bindings.empty()) {
+            // Find the variant's payload types so we can give bindings the right type
+            Symbol* enum_sym = scopes_.lookup(arm.pattern.enum_name);
+            const sema::EnumVariantInfo* vi = nullptr;
+            if (enum_sym && types_.info(enum_sym->type).kind == TypeKind::Enum) {
+                for (const auto& v : types_.info(enum_sym->type).variants)
+                    if (v.name == arm.pattern.variant_name) { vi = &v; break; }
+            }
+            for (int i = 0; i < (int)arm.pattern.bindings.size(); ++i) {
+                const std::string& bname = arm.pattern.bindings[i];
+                Symbol bs;
+                bs.name = bname;
+                bs.kind = SymKind::Var;
+                // Use the declared payload type when available, else object
+                bs.type = (vi && i < (int)vi->payload.size())
+                          ? vi->payload[i] : TR::TID_OBJECT;
+                scopes_.define(bname, bs);
+            }
+        }
         check_stmts(arm.body);
         scopes_.pop();
     }
@@ -846,10 +866,10 @@ TypeId Sema::check_binary(const ast::BinaryExpr& e) {
     // Arithmetic operators
     if (op == "+" || op == "-" || op == "*" || op == "/" || op == "%") {
         if (op == "+" && (L == TR::TID_STR || R == TR::TID_STR)) {
-            // String concatenation — either side can be str; warn on type mismatch
-            if (L != TR::TID_STR)
+            // String concatenation — either side can be str or object; warn on other types
+            if (L != TR::TID_STR && L != TR::TID_OBJECT)
                 warn(e.left->loc,  "'+' with str: left operand is '" + types_.name_of(L) + "'");
-            if (R != TR::TID_STR)
+            if (R != TR::TID_STR && R != TR::TID_OBJECT)
                 warn(e.right->loc, "'+' with str: right operand is '" + types_.name_of(R) + "'");
             return TR::TID_STR;
         }

--- a/stdlib/result.dux
+++ b/stdlib/result.dux
@@ -1,30 +1,17 @@
-# stdlib/result.dux — Result type
+# stdlib/result.dux — Result type with payload
 #
-# Represents either success (Ok) or failure (Err).
-# Note: full generic parameterization (Result<T,E>) requires the generics
-# milestone. Until then, this provides the Ok/Err discriminant enum.
+# Result.Ok(value)  — success carrying an object payload
+# Result.Err(msg)   — failure carrying a str error message
+#
+# Usage:
+#   Result r = Result.Ok(myValue)
+#   Result r = Result.Err("something went wrong")
+#   match r {
+#       Result.Ok(val)  => ...
+#       Result.Err(msg) => print("error: " + msg)
+#   }
 
 enum Result {
-    Ok,
-    Err
-}
-
-# Helper: return the Ok discriminant
-int result_ok() {
-    return Result.Ok
-}
-
-# Helper: return the Err discriminant
-int result_err() {
-    return Result.Err
-}
-
-# Check if a result is Ok
-bool result_is_ok(int res) {
-    return res == Result.Ok
-}
-
-# Check if a result is Err
-bool result_is_err(int res) {
-    return res == Result.Err
+    Ok(object),
+    Err(str)
 }

--- a/tests/run_ok/enum_payload.dux
+++ b/tests/run_ok/enum_payload.dux
@@ -1,0 +1,63 @@
+import result
+
+# Local enum with mixed variants (some with payload, some without)
+enum Shape {
+    Circle(int),
+    Rect(int),
+    Dot
+}
+
+int main() {
+    # Test 1: Result.Ok carries a value
+    object r1 = Result.Ok("hello")
+    match r1 {
+        Result.Ok(val) => {
+            print("ok:" + val)
+        }
+        Result.Err(msg) => {
+            print("unexpected err")
+        }
+    }
+
+    # Test 2: Result.Err carries an error string
+    object r2 = Result.Err("not found")
+    match r2 {
+        Result.Ok(val) => {
+            print("unexpected ok")
+        }
+        Result.Err(msg) => {
+            print("err:" + msg)
+        }
+    }
+
+    # Test 3: payload variant — circle
+    object s1 = Shape.Circle(42)
+    match s1 {
+        Shape.Circle(r) => {
+            print("circle")
+        }
+        Shape.Rect(w) => {
+            print("rect")
+        }
+        Shape.Dot => {
+            print("dot")
+        }
+    }
+
+    # Test 4: no-payload variant in a payload enum
+    object s2 = Shape.Dot
+    match s2 {
+        Shape.Circle(r) => {
+            print("circle")
+        }
+        Shape.Rect(w) => {
+            print("rect")
+        }
+        Shape.Dot => {
+            print("dot")
+        }
+    }
+
+    print("enum_payload ok")
+    return 0
+}

--- a/tests/run_ok/enum_payload.expected
+++ b/tests/run_ok/enum_payload.expected
@@ -1,0 +1,5 @@
+ok:hello
+err:not found
+circle
+dot
+enum_payload ok


### PR DESCRIPTION
- Parser: match arm patterns extended with payload binding syntax
  Result.Err(msg) => { ... } — ident_list rule already existed, reused
- AST: MatchPattern gains 'bindings: vector<string>' for payload var names
- Codegen:
  - build_enum_type: copies payload TypeIds into EnumVariantInfo (was dropped)
  - lower_type: payload enums lower to ptr; simple enums stay i32
  - gen_member: no-payload variant in payload enum → alloc heap struct
    (tag at byte 0, ptr slots following); payload variant without args → warn
  - gen_call: intercepts EnumType.Variant(args) before class method lookup
  - gen_enum_ctor: mallocs (1+max_arity)*8 bytes, stores i32 tag + boxed fields
  - gen_match: detects ptr match subject → loads i32 tag from offset 0;
    binds payload fields per arm via unbox_from_ptr
  - box_to_ptr / unbox_from_ptr: shared boxing helpers (same as async env)
- Sema: check_match injects binding symbols into arm scope so sema accepts
  payload binding variables; str+object concat warning suppressed
- Stdlib: result.dux → enum Result { Ok(object), Err(str) }
- Tests: tests/run_ok/enum_payload.{dux,expected} — Result + Shape variants;
  all 166 tests pass

https://claude.ai/code/session_013268REeAo1j62C7yC5BB9P