### PR TITLE
release: bump version to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-05-26
+
+### Fixed
+
+- **Codegen — `thread_local` globals orphaned in LLVM IR:** Global variables
+  declared with `thread_local` were created _after_ function bodies were
+  compiled, so every reference inside a function silently fell back to a fresh
+  local `alloca`; the `GlobalVariable` nodes existed in the IR but were never
+  used. Fixed by adding a pre-pass (Pass 3.5) that declares all
+  `thread_local` module-scope globals before function bodies are compiled.
+- **Socket — platform-specific `SOL_SOCKET`/`SO_REUSEADDR` constants:**
+  The test was calling `set_opt(1, 2, 1)` with Linux-specific numeric constants
+  (`SOL_SOCKET=1`, `SO_REUSEADDR=2`); on macOS these are `0xffff`/`4`, causing
+  the call to fail silently. Added `duxrt_sock_set_reuseaddr` /
+  `duxrt_sock_set_reuseport` runtime helpers that use `<sys/socket.h>` platform
+  constants, exposed as `set_reuseaddr()` / `set_reuseport()` on `Socket`.
+- **macOS build — missing `<signal.h>` in `process_rt.c`:** `kill()` requires
+  `<signal.h>` on macOS; it is not pulled in transitively by `<sys/types.h>`.
+- **macOS build — Clang rejects `__extension__` for flexible-array-member
+  warning:** Replaced `__extension__ char data[]` with a `#pragma clang
+  diagnostic` block in `duxrt.h` so Apple Clang accepts the FAM without
+  `-Wc99-extensions`.
+- **macOS linker — `-lstdc++` removed in macOS 10.15:** The linker invocation
+  in `main.cpp` and `CMakeLists.txt` now uses `-lc++` on Apple platforms and
+  `-lstdc++` on Linux.
+- **macOS Release build — `-march=native` miscompilation on Apple Silicon:**
+  `-march=native` is now opt-in (`-DDUX_MARCH_NATIVE=ON`); it defaults to OFF
+  so that CI and distributed binaries are not compiled for a specific M-chip
+  micro-architecture.
+- **macOS linker — OpenSSL library resolution ambiguity:** When Homebrew's
+  `clang-18` is `cc`, bare `-lssl -lcrypto` flags may resolve to the wrong
+  LibreSSL stubs. The exact `OPENSSL_SSL_LIBRARY` / `OPENSSL_CRYPTO_LIBRARY`
+  paths found by CMake are now baked into the `dux` binary at build time and
+  used when linking user programs.
+- **Compiler warnings — zero-warning build across GCC 13, Clang 18, and Apple
+  Clang:** Eliminated all `-Wall -Wextra -Wpedantic` warnings in source,
+  generated parser/lexer, and grammar files.
+
+---
+
 ## [0.1.2] - 2026-05-26
 
 ### Fixed
@@ -204,5 +244,6 @@ Initial public release of the Dux programming language compiler.
   - Heap alloc/free (1 M cycles): 2 ms - **faster than C**
   - Beats Go on 5 of 7 tracked workloads; within 2× of C on 6 of 7.
 
+[0.1.3]: https://github.com/vorjdux/dux-lang/releases/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/vorjdux/dux-lang/releases/compare/v0.1.0...v0.1.2
 [0.1.0]: https://github.com/vorjdux/dux-lang/releases/tag/v0.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 project(dux-lang
-    VERSION     0.1.2
+    VERSION     0.1.3
     DESCRIPTION "The Dux programming language compiler"
     LANGUAGES   C CXX
 )
@@ -305,7 +305,7 @@ set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS  "libc6 (>= 2.17), libstdc++6 (>= 9)")
 set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "clang-18")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Dux Lang <vorj.dux@gmail.com>")
-# Naming: dux-lang_0.1.2_amd64.deb
+# Naming: dux-lang_0.1.3_amd64.deb
 set(CPACK_DEBIAN_FILE_NAME        "DEB-DEFAULT")
 
 # ── RPM package (.rpm) ────────────────────────────────────────────────────────
@@ -317,7 +317,7 @@ set(CPACK_RPM_PACKAGE_RECOMMENDS  "clang18")
 set(CPACK_RPM_PACKAGE_DESCRIPTION
 "Dux is a statically-typed compiled language targeting native code via LLVM.
 Clean Python-like syntax, classes, closures, async/await, LTO, -O3 performance.")
-# Naming: dux-lang-0.1.2-1.x86_64.rpm
+# Naming: dux-lang-0.1.3-1.x86_64.rpm
 set(CPACK_RPM_FILE_NAME           "RPM-DEFAULT")
 
 # Generators: TGZ for all platforms; DEB on Debian/Ubuntu; RPM on Fedora/RHEL

--- a/README.md
+++ b/README.md
@@ -29,34 +29,34 @@ Download from the [latest release](https://github.com/vorjdux/dux-lang/releases/
 
 | Platform | Package |
 |----------|---------|
-| Ubuntu 22.04 / 24.04 | `dux-lang_0.1.2_amd64.deb` |
-| Debian Bookworm | `dux-0.1.2-linux-x86_64-debian.tar.gz` |
-| Fedora / RHEL | `dux-lang-0.1.2-1.x86_64.rpm` |
-| macOS Apple Silicon | `dux-0.1.2-macos-arm64.tar.gz` |
-| macOS Intel | `dux-0.1.2-macos-x86_64.tar.gz` |
-| Generic Linux x86_64 | `dux-0.1.2-linux-x86_64.tar.gz` |
+| Ubuntu 22.04 / 24.04 | `dux-lang_0.1.3_amd64.deb` |
+| Debian Bookworm | `dux-0.1.3-linux-x86_64-debian.tar.gz` |
+| Fedora / RHEL | `dux-lang-0.1.3-1.x86_64.rpm` |
+| macOS Apple Silicon | `dux-0.1.3-macos-arm64.tar.gz` |
+| macOS Intel | `dux-0.1.3-macos-x86_64.tar.gz` |
+| Generic Linux x86_64 | `dux-0.1.3-linux-x86_64.tar.gz` |
 
 **Ubuntu / Debian:**
 ```bash
-wget https://github.com/vorjdux/dux-lang/releases/download/v0.1.2/dux-lang_0.1.2_amd64.deb
-sudo dpkg -i dux-lang_0.1.2_amd64.deb
+wget https://github.com/vorjdux/dux-lang/releases/download/v0.1.3/dux-lang_0.1.3_amd64.deb
+sudo dpkg -i dux-lang_0.1.3_amd64.deb
 ```
 
 **Fedora / RHEL:**
 ```bash
-sudo dnf localinstall dux-lang-0.1.2-1.x86_64.rpm
+sudo dnf localinstall dux-lang-0.1.3-1.x86_64.rpm
 ```
 
 **macOS / Generic Linux (tarball):**
 ```bash
-tar -xzf dux-0.1.2-linux-x86_64.tar.gz
+tar -xzf dux-0.1.3-linux-x86_64.tar.gz
 sudo mv dux /usr/local/bin/
 ```
 
 ### Verify
 
 ```bash
-dux --version   # dux 0.1.2 (x86_64-Linux)
+dux --version   # dux 0.1.3 (x86_64-Linux)
 dux --help
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ After installation, verify it worked:
 
 ```bash
 dux --version
-# dux 0.1.2 (x86_64-linux)
+# dux 0.1.3 (x86_64-linux)
 ```
 
 ### Installer options
@@ -24,7 +24,7 @@ You can control the installer with environment variables and flags:
 
 ```bash
 # Install a specific version
-DUX_VERSION=0.1.2 curl -sSf https://raw.githubusercontent.com/vorjdux/dux-lang/master/install.sh | sh
+DUX_VERSION=0.1.3 curl -sSf https://raw.githubusercontent.com/vorjdux/dux-lang/master/install.sh | sh
 
 # Install to a custom directory (no sudo required)
 DUX_INSTALL_DIR=~/.local/bin curl -sSf https://raw.githubusercontent.com/vorjdux/dux-lang/master/install.sh | sh
@@ -46,8 +46,8 @@ Download the `.deb` package from the
 [GitHub Releases page](https://github.com/vorjdux/dux-lang/releases/latest):
 
 ```bash
-wget https://github.com/vorjdux/dux-lang/releases/download/v0.1.2/dux-lang_0.1.2_amd64.deb
-sudo dpkg -i dux-lang_0.1.2_amd64.deb
+wget https://github.com/vorjdux/dux-lang/releases/download/v0.1.3/dux-lang_0.1.3_amd64.deb
+sudo dpkg -i dux-lang_0.1.3_amd64.deb
 ```
 
 If `dpkg` reports missing dependencies, resolve them with:
@@ -69,10 +69,10 @@ Download the `.rpm` package from the
 
 ```bash
 # Fedora (dnf)
-sudo dnf localinstall dux-lang-0.1.2-1.x86_64.rpm
+sudo dnf localinstall dux-lang-0.1.3-1.x86_64.rpm
 
 # RHEL / CentOS (rpm)
-sudo rpm -i dux-lang-0.1.2-1.x86_64.rpm
+sudo rpm -i dux-lang-0.1.3-1.x86_64.rpm
 ```
 
 To remove:
@@ -110,21 +110,21 @@ extract it, and move the binary to a directory on your `PATH`.
 
 | Platform | Archive |
 |----------|---------|
-| Linux x86_64 | `dux-0.1.2-linux-x86_64.tar.gz` |
-| Linux ARM64 (aarch64) | `dux-0.1.2-linux-aarch64.tar.gz` |
-| macOS Apple Silicon (ARM64) | `dux-0.1.2-macos-aarch64.tar.gz` |
-| macOS Intel (x86_64) | `dux-0.1.2-macos-x86_64.tar.gz` |
+| Linux x86_64 | `dux-0.1.3-linux-x86_64.tar.gz` |
+| Linux ARM64 (aarch64) | `dux-0.1.3-linux-aarch64.tar.gz` |
+| macOS Apple Silicon (ARM64) | `dux-0.1.3-macos-aarch64.tar.gz` |
+| macOS Intel (x86_64) | `dux-0.1.3-macos-x86_64.tar.gz` |
 
 ```bash
 # Example: Linux x86_64
-wget https://github.com/vorjdux/dux-lang/releases/download/v0.1.2/dux-0.1.2-linux-x86_64.tar.gz
+wget https://github.com/vorjdux/dux-lang/releases/download/v0.1.3/dux-0.1.3-linux-x86_64.tar.gz
 
 # Verify checksum
-wget https://github.com/vorjdux/dux-lang/releases/download/v0.1.2/SHA256SUMS
+wget https://github.com/vorjdux/dux-lang/releases/download/v0.1.3/SHA256SUMS
 sha256sum --check --ignore-missing SHA256SUMS
 
 # Extract and install
-tar -xzf dux-0.1.2-linux-x86_64.tar.gz
+tar -xzf dux-0.1.3-linux-x86_64.tar.gz
 sudo mv dux /usr/local/bin/
 sudo chmod +x /usr/local/bin/dux
 ```
@@ -278,7 +278,7 @@ dux --version
 Expected output (version and platform may differ):
 
 ```
-dux 0.1.2 (x86_64-linux)
+dux 0.1.3 (x86_64-linux)
 ```
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ set -e
 
 REPO="vorjdux/dux-lang"
 BINARY_NAME="dux"
-DEFAULT_VERSION="0.1.2"
+DEFAULT_VERSION="0.1.3"
 
 # ─── Colour output ────────────────────────────────────────────────────────────
 
@@ -100,7 +100,7 @@ EXAMPLES:
     curl -sSf https://raw.githubusercontent.com/vorjdux/dux-lang/master/install.sh | sh
 
     # Install specific version
-    DUX_VERSION=0.1.2 curl -sSf https://raw.githubusercontent.com/vorjdux/dux-lang/master/install.sh | sh
+    DUX_VERSION=0.1.3 curl -sSf https://raw.githubusercontent.com/vorjdux/dux-lang/master/install.sh | sh
 
     # Dry run
     sh install.sh --dry-run

--- a/packaging/homebrew/dux-lang.rb
+++ b/packaging/homebrew/dux-lang.rb
@@ -1,17 +1,17 @@
 class DuxLang < Formula
   desc "The Dux programming language compiler"
   homepage "https://github.com/vorjdux/dux-lang"
-  version "0.1.2"
+  version "0.1.3"
   license "MIT"
 
   on_arm do
-    url "https://github.com/vorjdux/dux-lang/releases/download/v0.1.2/dux-0.1.2-macos-arm64.tar.gz"
+    url "https://github.com/vorjdux/dux-lang/releases/download/v0.1.3/dux-0.1.3-macos-arm64.tar.gz"
     # Update sha256 after publishing the release:
     # sha256 "<SHA256_OF_MACOS_ARM64_TARBALL>"
   end
 
   on_intel do
-    url "https://github.com/vorjdux/dux-lang/releases/download/v0.1.2/dux-0.1.2-macos-x86_64.tar.gz"
+    url "https://github.com/vorjdux/dux-lang/releases/download/v0.1.3/dux-0.1.3-macos-x86_64.tar.gz"
     # Update sha256 after publishing the release:
     # sha256 "<SHA256_OF_MACOS_X86_64_TARBALL>"
   end

--- a/packaging/rpm/dux-lang.spec
+++ b/packaging/rpm/dux-lang.spec
@@ -1,5 +1,5 @@
 Name:           dux-lang
-Version:        0.1.2
+Version:        0.1.3
 Release:        1%{?dist}
 Summary:        The Dux programming language compiler
 
@@ -50,6 +50,13 @@ standard library covering I/O, networking, threading, and data structures.
 %{_datadir}/dux/stdlib/
 
 %changelog
+* Mon May 26 2026 Dux Lang <vorj.dux@gmail.com> - 0.1.3-1
+- Fix thread_local globals orphaned in codegen (pre-declare before function bodies)
+- Fix socket portability: add set_reuseaddr/set_reuseport with platform constants
+- Fix macOS build: missing signal.h, FAM Clang warning, -lc++ vs -lstdc++
+- Fix macOS Release: -march=native now opt-in; bake OpenSSL paths at cmake time
+- Eliminate all compiler warnings across GCC 13, Clang 18, and Apple Clang
+
 * Tue May 26 2026 Dux Lang <vorj.dux@gmail.com> - 0.1.2-1
 - Fix CI on all four platforms (macOS, Ubuntu GCC/Clang, Fedora)
 - Resolve merge conflicts with master; bump spec to version 0.2


### PR DESCRIPTION
- CMakeLists.txt: PROJECT VERSION 0.1.2 -> 0.1.3
- CHANGELOG.md: add [0.1.3] section covering all fixes since 0.1.2
- README.md, docs/install.md, install.sh: update download URLs and version strings
- packaging/rpm/dux-lang.spec: bump Version + add changelog entry
- packaging/homebrew/dux-lang.rb: bump version and tarball URLs

Changes included in 0.1.3:
  - codegen: fix thread_local globals orphaned before function bodies
  - socket: portable set_reuseaddr/set_reuseport helpers
  - macOS: signal.h, FAM warning, -lc++, -march=native opt-in, OpenSSL paths
  - build: zero-warning compilation across GCC 13 / Clang 18 / Apple Clang