### PR TITLE
ci: drop macOS x86_64 release job (macos-13 runner unavailable)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,19 +88,10 @@ jobs:
           name: fedora-rpm
           path: build/dux-lang-*.rpm
 
-  # ── macOS arm64 + x86_64 — TGZ ─────────────────────────────────────────────
+  # ── macOS arm64 — TGZ ────────────────────────────────────────────────────────
   build-macos:
-    name: macOS ${{ matrix.arch }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: arm64
-            runner: macos-14
-          - arch: x86_64
-            runner: macos-13
-
+    name: macOS arm64
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
 
@@ -125,13 +116,13 @@ jobs:
         run: ctest --test-dir build --output-on-failure --verbose -j1
 
       - name: Package
-        # CPack produces: dux-<ver>-macos-arm64.tar.gz (or x86_64)
+        # CPack produces: dux-<ver>-macos-arm64.tar.gz
         run: cmake --build build --target package
 
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: macos-${{ matrix.arch }}
+          name: macos-arm64
           path: build/dux-*.tar.gz
 
   # ── Publish GitHub Release ────────────────────────────────────────────────────


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and packaging the macOS release. The main change is that the workflow now only builds for macOS arm64 architecture (dropping x86_64 support), and related steps and artifact naming have been simplified accordingly.

Build and packaging workflow updates:

* The `build-macos` job in `.github/workflows/release.yml` now only targets the arm64 architecture, running exclusively on `macos-14`, instead of using a matrix to build both arm64 and x86_64.
* Artifact naming and documentation in the packaging and upload steps have been updated to reflect that only the arm64 tarball is produced and uploaded.