### PR TITLE
repl: accumulate statements so variables persist across lines

### DIFF
--- a/src/repl/repl.cpp
+++ b/src/repl/repl.cpp
@@ -87,11 +87,20 @@ bool Repl::is_decl(const std::string& line) const {
 
 std::string Repl::build_source(const std::string& stmt) const {
     std::string src;
+    // Top-level declarations (functions, classes, …)
     for (const auto& d : context_decls_) {
         src += d;
         src += "\n";
     }
-    src += "void main() {\n    ";
+    src += "void main() {\n";
+    // Replay all previously accepted statements so variables remain in scope.
+    for (const auto& s : context_stmts_) {
+        src += "    ";
+        src += s;
+        src += "\n";
+    }
+    // New statement goes last.
+    src += "    ";
     src += stmt;
     src += "\n}\n";
     return src;
@@ -209,7 +218,11 @@ void Repl::run() {
                 "  Define functions/classes first, then call them.\n"
                 "  Declarations (class, fn, void/int/str/... name(...) {...}) are\n"
                 "  accumulated and available to all subsequent statements.\n"
-                "  Statements are compiled and run immediately.\n"
+                "  Statements are accumulated too: variables declared on one\n"
+                "  line are in scope on every following line.\n"
+                "  Note: accumulated statements are replayed on each new line,\n"
+                "  so side-effectful calls (print, file I/O) will run again.\n"
+                "  Use :clear to reset all accumulated state.\n"
 #ifdef DUX_RL
                 "  Up/Down arrows navigate command history.\n"
                 "  Left/Right arrows and Ctrl+A/E/K/U edit the current line.\n"
@@ -220,16 +233,23 @@ void Repl::run() {
 
         if (line == ":clear") {
             context_decls_.clear();
+            context_stmts_.clear();
             std::cout << "Context cleared.\n";
             continue;
         }
 
         if (line == ":context") {
-            if (context_decls_.empty()) {
+            if (context_decls_.empty() && context_stmts_.empty()) {
                 std::cout << "(empty)\n";
             } else {
                 for (const auto& d : context_decls_)
                     std::cout << d << "\n";
+                if (!context_stmts_.empty()) {
+                    std::cout << "void main() {\n";
+                    for (const auto& s : context_stmts_)
+                        std::cout << "    " << s << "\n";
+                    std::cout << "    ...\n}\n";
+                }
             }
             continue;
         }
@@ -275,7 +295,12 @@ void Repl::run() {
             }
         } else {
             std::string src = build_source(line);
-            compile_and_run(src);
+            int rc = compile_and_run(src);
+            // Accumulate on success so variables remain in scope for
+            // subsequent statements.  On failure nothing is added, keeping
+            // the context clean.
+            if (rc == 0)
+                context_stmts_.push_back(line);
         }
     }
 

--- a/src/repl/repl.hpp
+++ b/src/repl/repl.hpp
@@ -6,7 +6,8 @@ namespace dux {
 
 class Repl {
     std::string              dux_binary_;    // path to this binary (argv[0])
-    std::vector<std::string> context_decls_; // accumulated declarations
+    std::vector<std::string> context_decls_; // accumulated top-level declarations
+    std::vector<std::string> context_stmts_; // accumulated statements (replayed in main)
     std::string              temp_dir_;
 
 public:


### PR DESCRIPTION
Previously every statement was compiled in its own fresh void main(), so variables from line N were out of scope on line N+1.

Fix: add context_stmts_ (alongside the existing context_decls_). After each successfully compiled-and-run statement the line is pushed into context_stmts_.  build_source() replays all accumulated statements before the new one, so variables, assignments, and any other bindings remain in scope for the rest of the session.

  dux> int i = 10
  dux> println(f"i+1 = {i+1}")
  i+1 = 11                          ← now works

Known limitation: accumulated statements are replayed on every new line, so lines with side effects (print, file I/O) run again each time a new statement is added.  :clear resets all accumulated state.

:clear now clears context_stmts_ in addition to context_decls_. :context now shows the accumulated statement block. :help updated to document the replay behaviour.