### PR TITLE
cmake: fix CPack TGZ naming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,16 +370,24 @@ set(CPACK_RESOURCE_FILE_README  "${CMAKE_SOURCE_DIR}/README.md")
 set(CPACK_STRIP_FILES TRUE)
 
 # ── Tarball (.tar.gz) ────────────────────────────────────────────────────────
-# Produces: dux-<version>-linux-x86_64.tar.gz  /  dux-<version>-macos-arm64.tar.gz
+# Produces: dux-<version>-linux-x86_64.tar.gz  /  dux-<version>-macos-aarch64.tar.gz
 # Use "macos" instead of "darwin" for friendlier file names.
+# Normalize "arm64" → "aarch64" to match install.sh arch detection.
 if(APPLE)
     set(_dux_platform "macos")
 else()
     string(TOLOWER "${CMAKE_SYSTEM_NAME}" _dux_platform)
 endif()
-set(CPACK_ARCHIVE_FILE_NAME
-    "dux-${PROJECT_VERSION}-${_dux_platform}-${CMAKE_SYSTEM_PROCESSOR}")
-string(TOLOWER "${CPACK_ARCHIVE_FILE_NAME}" CPACK_ARCHIVE_FILE_NAME)
+# Normalize arm64 → aarch64 to match install.sh _detect_arch() mapping
+string(REPLACE "arm64" "aarch64" _dux_arch "${CMAKE_SYSTEM_PROCESSOR}")
+string(TOLOWER "${_dux_arch}" _dux_arch)
+set(_dux_pkg_name "dux-${PROJECT_VERSION}-${_dux_platform}-${_dux_arch}")
+# CPACK_PACKAGE_FILE_NAME controls the TGZ output name; CPACK_ARCHIVE_FILE_NAME
+# is an alias honoured in some CMake versions — set both for maximum compatibility.
+# DEB uses CPACK_DEBIAN_FILE_NAME=DEB-DEFAULT and RPM uses RPM-DEFAULT, so they
+# are not affected by CPACK_PACKAGE_FILE_NAME.
+set(CPACK_ARCHIVE_FILE_NAME "${_dux_pkg_name}")
+set(CPACK_PACKAGE_FILE_NAME "${_dux_pkg_name}")
 
 # ── Debian package (.deb) ─────────────────────────────────────────────────────
 set(CPACK_DEBIAN_PACKAGE_SECTION  "devel")


### PR DESCRIPTION
This pull request updates the packaging logic in `CMakeLists.txt` to standardize the architecture naming in generated tarball filenames, ensuring consistency with the architecture detection in the installation script. The most important changes are:

Packaging improvements:

* Normalized the architecture name from `arm64` to `aarch64` in tarball filenames to match the `install.sh` script's architecture detection logic. This affects files like `dux-<version>-macos-aarch64.tar.gz` instead of the previous `arm64` variant.
* Updated the code to set both `CPACK_ARCHIVE_FILE_NAME` and `CPACK_PACKAGE_FILE_NAME` for maximum compatibility across different CMake versions and packaging systems.

Documentation:

* Clarified comments to explain the rationale for the filename normalization and the distinction between different packaging variables.…PACK_ARCHIVE_FILE_NAME

CPACK_ARCHIVE_FILE_NAME is honoured by some CMake/CPack versions but the TGZ generator reliably uses CPACK_PACKAGE_FILE_NAME as its output stem. Without it CPack falls back to the default
  ${CPACK_PACKAGE_NAME}-${VERSION}-${CPACK_SYSTEM_NAME}
which produces dux-lang-0.1.3-Linux.tar.gz instead of the expected dux-0.1.3-linux-x86_64.tar.gz.

DEB and RPM generators are unaffected because they use DEB-DEFAULT / RPM-DEFAULT respectively, which override CPACK_PACKAGE_FILE_NAME.

Also normalize CMAKE_SYSTEM_PROCESSOR arm64 → aarch64 so the macOS tarball name (dux-0.1.3-macos-aarch64.tar.gz) matches what install.sh resolves via its _detect_arch() uname -m mapping.